### PR TITLE
refactor: drop support for Dart-specific `!!uri` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ The secondary tag handle `!!` is limited to tags below which all resolve to the 
   - `!!int` - Integer. `hex`, `octal` and `base 10` should use this.
   - `!!float` - double.
 
-- `Dart`-specific schema tags
-  - `!!uri` - URI
-
 > [!WARNING]
 > The Dart-specific secondary tags may be moved to a custom global tag prefix.
 

--- a/doc/schema_tags.md
+++ b/doc/schema_tags.md
@@ -10,6 +10,3 @@ The secondary tag handle `!!` is limited to tags below which all resolve to the 
   - `!!bool` - Boolean.
   - `!!int` - Integer. `hex`, `octal` and `base 10` should use this.
   - `!!float` - double.
-
-- `Dart`-specific schema tags (More will be supported)
-  - `!!uri` - URI

--- a/lib/src/schema/safe_type_wrappers/typed_schema_utils.dart
+++ b/lib/src/schema/safe_type_wrappers/typed_schema_utils.dart
@@ -156,8 +156,6 @@ const _notInferred = (null, null);
 _MaybeInferred<T> _inferDartType<T>(String content) {
   if (double.tryParse(content) case double parsedFloat) {
     return (floatTag, parsedFloat as T);
-  } else if (Uri.tryParse(content) case Uri uri when uri.scheme.isNotEmpty) {
-    return (uriTag, uri as T);
   } else if (bool.tryParse(content) case bool boolean) {
     /// - Just "true" and "false". Schema should be language specific but also
     ///   agnostic when representing values. Booleans are lowercase in Dart

--- a/lib/src/schema/yaml_schema.dart
+++ b/lib/src/schema/yaml_schema.dart
@@ -58,26 +58,10 @@ final integerTag = TagShorthand.fromTagUri(_defaultYamlHandle, 'int');
 /// {@category schema}
 final floatTag = TagShorthand.fromTagUri(_defaultYamlHandle, 'float');
 
-//
-// ** Dart Tags **
-//
-
-/// [Uri] tag
-///
-/// {@category schema}
-final uriTag = TagShorthand.fromTagUri(_defaultYamlHandle, 'uri');
-
 /// Any [TagShorthand] that resolves to a [Scalar]
 ///
 /// {@category schema}
-final scalarTags = {
-  stringTag,
-  nullTag,
-  booleanTag,
-  integerTag,
-  floatTag,
-  uriTag,
-};
+final scalarTags = {stringTag, nullTag, booleanTag, integerTag, floatTag};
 
 /// Checks if a [tag] is valid tag in the yaml schema. A yaml tag uses the
 /// [TagHandleVariant.secondary] handle

--- a/test/type_inference_test.dart
+++ b/test/type_inference_test.dart
@@ -176,31 +176,6 @@ void main() {
     );
   });
 
-  test('Infers Uri in different scalars', () {
-    final uri = Uri.https('i.love.dart');
-
-    final yaml =
-        '''
-- "$uri" # Double quoted
-- '$uri' # Single quoted
--  $uri  # Plain
-- |-     # Literal
-   $uri
-- >-     # Folded
-   $uri
-''';
-
-    check(
-      bootstrapDocParser(yaml).parseDocuments().parseNodeSingle(),
-    ).isA<Sequence>().every(
-      (d) => d.isA<Scalar>().which(
-        (d) => d
-          ..hasTag(yamlGlobalTag, suffix: uriTag)
-          ..hasInferred('Uri', uri),
-      ),
-    );
-  });
-
   test('Defaults to string', () {
     const expected = 'Just a string';
 


### PR DESCRIPTION
Using `!!uri` will now throw as it is now not a supported secondary tag. API users will have to pass in a custom `Resolver` if they want to infer `Uri` types. I think going forward this will be the expectation. 

Dart-specific behaviour **WILL** also be implemented using custom `Resolver`s. This allows the parser to be flexible while maintaining a low probability of enforcing heuristics API users do not expect.