### PR TITLE
refactor(dumper): rename `write`  to `writeInline` in `YamlBuffer`

### DIFF
--- a/packages/dump_yaml/lib/src/dumper/block_dumper.dart
+++ b/packages/dump_yaml/lib/src/dumper/block_dumper.dart
@@ -29,7 +29,7 @@ final class BlockDumper extends Dumper<TreeNode<Object>> with TreeNodeVisitor {
   final _collectionIndents = ListQueue<int>();
 
   @override
-  void visitAliasNode(ReferenceNode node) => buffer.write(node.node);
+  void visitAliasNode(ReferenceNode node) => buffer.writeInline(node.node);
 
   @override
   void visitContentNode(ContentNode node) {
@@ -174,7 +174,7 @@ final class BlockDumper extends Dumper<TreeNode<Object>> with TreeNodeVisitor {
     visitTreeNode(key);
 
     // Aliases allow ":".
-    buffer.write('${key is ReferenceNode ? ' ' : ''}:');
+    buffer.writeInline('${key is ReferenceNode ? ' ' : ''}:');
 
     final valueIndent = entryIndent + buffer.step;
     buffer.indent = valueIndent;

--- a/packages/dump_yaml/lib/src/dumper/dumper.dart
+++ b/packages/dump_yaml/lib/src/dumper/dumper.dart
@@ -88,15 +88,15 @@ extension DumperHelpers on YamlBuffer {
     distanceFromMargin = 0;
   }
 
-  /// Writes the [content].
-  void write(String content) {
+  /// Writes [content] inline.
+  void writeInline(String content) {
     _writer(content);
     distanceFromMargin += content.length;
     lastWasLineEnding = false;
   }
 
   /// Writes the indent or the number of spaces if [count] is specified.
-  void writeSpaceOrIndent([int? count]) => write(' ' * (count ?? indent));
+  void writeSpaceOrIndent([int? count]) => writeInline(' ' * (count ?? indent));
 
   /// Writes the [lines] to the underlying buffer.
   ///

--- a/packages/dump_yaml/lib/src/dumper/preamble.dart
+++ b/packages/dump_yaml/lib/src/dumper/preamble.dart
@@ -27,7 +27,7 @@ bool exitAfterPreamble<T>(
   if (!node.forcedInline) return _writePreamble(buffer, node);
 
   dumper.dump(node);
-  buffer.write(dumper.dumped());
+  buffer.writeInline(dumper.dumped());
   dumper.reset();
   return true;
 }
@@ -40,7 +40,7 @@ bool _writePreamble<T>(YamlBuffer buffer, CollectionNode<T> collection) {
   ].join(' ');
 
   if (collection.node.isEmpty) {
-    buffer.write(
+    buffer.writeInline(
       '${props.isNotEmpty ? '$props ' : ''}'
       '${collection.nodeType == NodeType.map ? '{}' : '[]'}',
     );
@@ -58,7 +58,7 @@ bool _writePreamble<T>(YamlBuffer buffer, CollectionNode<T> collection) {
 /// Writes the flow collection's properties to the [buffer].
 void _flowPreamble(YamlBuffer buffer, String props, NodeType nodeType) {
   if (props.isNotEmpty) {
-    buffer.write('$props ');
+    buffer.writeInline('$props ');
   }
 
   // ```yaml
@@ -79,7 +79,7 @@ void _flowPreamble(YamlBuffer buffer, String props, NodeType nodeType) {
   // ]
   //```
   buffer
-    ..write(nodeType == NodeType.map ? '{' : '[')
+    ..writeInline(nodeType == NodeType.map ? '{' : '[')
     ..moveToNextLine()
     ..writeSpaceOrIndent(buffer.indent + buffer.step); // Indent of child
 }
@@ -104,7 +104,7 @@ void _blockPreamble(YamlBuffer buffer, String props) {
   // - next
   //```
   buffer
-    ..write(props)
+    ..writeInline(props)
     ..moveToNextLine()
     ..writeSpaceOrIndent();
 }
@@ -126,7 +126,7 @@ void collectionEnd(
 
   buffer
     ..writeSpaceOrIndent()
-    ..write(nodeType == NodeType.map ? '}' : ']');
+    ..writeInline(nodeType == NodeType.map ? '}' : ']');
 }
 
 /// Writes the [comments] provided to the [buffer].
@@ -168,7 +168,7 @@ void blockEntryStart(
 
     if (charIfPossessive.isNotEmpty) {
       buffer
-        ..write(charIfPossessive)
+        ..writeInline(charIfPossessive)
         ..writeSpaceOrIndent(1);
     }
 
@@ -184,7 +184,7 @@ void blockEntryStart(
   //   node
   // ```
   buffer
-    ..write(charIfPossessive)
+    ..writeInline(charIfPossessive)
     ..writeSpaceOrIndent(1);
 
   // Use the entry indent
@@ -226,7 +226,7 @@ void flowEntryEnd(
     //   next value
     // ]
     buffer
-      ..write(',')
+      ..writeInline(',')
       ..moveToNextLine()
       ..writeSpaceOrIndent();
 

--- a/packages/dump_yaml/lib/src/dumper/yaml_dumper.dart
+++ b/packages/dump_yaml/lib/src/dumper/yaml_dumper.dart
@@ -136,7 +136,7 @@ final class YamlDumper extends Dumper<Object?> {
   }
 
   void _endOfDirectives(YamlBuffer buffer) => buffer
-    ..write(DocumentMarker.directiveEnd.indicator)
+    ..writeInline(DocumentMarker.directiveEnd.indicator)
     ..moveToNextLine();
 
   /// Dumps the [node] as a valid YAML document based on the current
@@ -176,7 +176,7 @@ final class YamlDumper extends Dumper<Object?> {
 
     if (_addDocEnd) {
       if (!buffer.lastWasLineEnding) buffer.moveToNextLine();
-      buffer.write(DocumentMarker.documentEnd.indicator);
+      buffer.writeInline(DocumentMarker.documentEnd.indicator);
     }
 
     _treeConfig = null; // [TreeBuilder] persists its copy.


### PR DESCRIPTION
The method was confusing and didn't correctly convey that the method only writes inline content.