### PR TITLE
feat(dumper): detect equality anomalies

### DIFF
--- a/packages/dump_yaml/lib/dump_yaml.dart
+++ b/packages/dump_yaml/lib/dump_yaml.dart
@@ -5,7 +5,7 @@ export 'src/dumper/block_dumper.dart';
 export 'src/dumper/dumper.dart' show YamlBuffer;
 export 'src/dumper/inline_flow_dumper.dart';
 export 'src/dumper/yaml_dumper.dart';
-export 'src/event_tree/node.dart' hide Doc;
+export 'src/event_tree/node.dart' hide Doc, isRecursiveAnchorRef;
 export 'src/event_tree/tree_builder.dart' show GTags, PathLogger, TreeBuilder;
 export 'src/strings.dart' show Normalized, splitUnfoldScanned;
 export 'src/unfolding.dart';

--- a/packages/dump_yaml/lib/src/event_tree/node.dart
+++ b/packages/dump_yaml/lib/src/event_tree/node.dart
@@ -66,8 +66,15 @@ abstract class TreeNode<T> extends CompactYamlNode {
 
 /// An alias.
 final class ReferenceNode extends TreeNode<String> {
-  ReferenceNode(this.alias, {required super.comments, super.commentStyle})
-    : super(NodeStyle.flow);
+  ReferenceNode(
+    this.alias, {
+    required super.comments,
+    super.commentStyle,
+    this.recursive = false,
+  }) : super(NodeStyle.flow);
+
+  /// Whether `this` is recursive.
+  final bool recursive;
 
   @override
   final String alias;
@@ -148,6 +155,19 @@ extension on CommentStyle {
     CommentStyle.possessive || CommentStyle.trailing => true,
     _ => false,
   };
+}
+
+bool isRecursiveAnchorRef(Object? object, String? anchor) {
+  bool isRef(Object? node) {
+    if (node is! ReferenceNode || !node.recursive) return false;
+    return anchor == null || anchor == node.alias;
+  }
+
+  if (object case MappingEntry(:final $1, :final $2)) {
+    return isRef($1) || isRef($2);
+  }
+
+  return isRef(object);
 }
 
 extension KeyUtil on TreeNode<Object> {

--- a/packages/dump_yaml/lib/src/event_tree/node.dart
+++ b/packages/dump_yaml/lib/src/event_tree/node.dart
@@ -160,7 +160,7 @@ extension on CommentStyle {
 bool isRecursiveAnchorRef(Object? object, String? anchor) {
   bool isRef(Object? node) {
     if (node is! ReferenceNode || !node.recursive) return false;
-    return anchor == null || anchor == node.alias;
+    return anchor != null && anchor == node.alias;
   }
 
   if (object case MappingEntry(:final $1, :final $2)) {

--- a/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
+++ b/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
@@ -263,11 +263,17 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   /// Visits a recursive [object] and tracks the object's state.
   void _visitRecursiveCandidate<T>(
     T object, {
-    required void Function(String recursiveAnchor, T object) visit,
+    required void Function(String? recursiveAnchor, T object) visit,
+    required bool trackObject,
     String? anchorOnVisit,
     Iterable<String>? comments,
     CommentStyle? commentStyle,
   }) {
+    if (!trackObject) {
+      visit(null, object);
+      return;
+    }
+
     if (_recursiveTracker[object] case String anchored) {
       _addNode(
         ReferenceNode(
@@ -317,6 +323,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   @override
   void visitIterable(Iterable<Object?> iterable) => _visitRecursiveCandidate(
     iterable,
+    trackObject: true,
     visit: (anchor, object) => _buildIterable(
       object,
       style: _config.iterableStyle,
@@ -328,10 +335,11 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
 
   @override
   void visitIterableView(YamlIterable iterable) {
-    final YamlIterable(:anchor, :comments, :commentStyle) = iterable;
+    final YamlIterable(:node, :anchor, :comments, :commentStyle) = iterable;
 
     _visitRecursiveCandidate(
       iterable.node,
+      trackObject: node is Iterable,
       anchorOnVisit: _pushAnchor(anchor),
       comments: comments,
       commentStyle: commentStyle,
@@ -355,6 +363,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   @override
   void visitMap(Map<Object?, Object?> map) => _visitRecursiveCandidate(
     map,
+    trackObject: true,
     visit: (anchor, object) => _buildMap(
       object.entries,
       style: _config.mapStyle,
@@ -366,10 +375,11 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
 
   @override
   void visitMappingView(YamlMapping mapping) {
-    final YamlMapping(:anchor, :comments, :commentStyle) = mapping;
+    final YamlMapping(:node, :anchor, :comments, :commentStyle) = mapping;
 
     _visitRecursiveCandidate(
       mapping.node,
+      trackObject: node is Map,
       anchorOnVisit: _pushAnchor(anchor),
       comments: comments,
       commentStyle: commentStyle,

--- a/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
+++ b/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
@@ -305,7 +305,10 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
         mapping;
 
     _buildMap(
-      mapping.toFormat(mapping.node),
+      LinkedHashSet<MapEntry<Object?, Object?>>(
+        equals: (p0, p1) => p0.key == p1.key,
+        hashCode: (p0) => p0.key.hashCode,
+      )..addAll(mapping.toFormat(mapping.node)),
       style: nodeStyle,
       forceInline: forceInline || _inlineRules.last,
       comments: comments,

--- a/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
+++ b/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
@@ -192,6 +192,32 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   /// Whether to reset the global tags before building the tree.
   var _resetTags = false;
 
+  /// Number of anonymous objects without an anchor. Used as a suffix.
+  int? _recursiveCount;
+
+  /// Tracks the current collection-like object being walked.
+  final _recursiveTracker = HashMap<Object?, String>.identity();
+
+  /// Links an [object] to an [anchor] just before the builder walks.
+  String _trackRecursive(Object? object, [String? anchor]) {
+    String fetchCount() {
+      var out = '';
+
+      if (_recursiveCount != null) {
+        out = '-${_recursiveCount!.toString()}';
+        _recursiveCount = _recursiveCount! + 1;
+      } else {
+        _recursiveCount = 0;
+      }
+
+      return out;
+    }
+
+    final tracker = anchor ?? 'recursive${fetchCount()}';
+    _recursiveTracker[object] = tracker;
+    return tracker;
+  }
+
   /// Throws a [StateError] with the [message] and includes the [_currentPath].
   Never _stateErrorWithPath(String message) =>
       _stateError('$message\n\tPath: ${_typePath.join('->')}');
@@ -204,6 +230,8 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     _collectionStyles.clear();
     _inlineRules.clear();
     _typePath.clear();
+    _recursiveCount = null;
+    _recursiveTracker.clear();
   }
 
   /// Adds the [node] to the LIFO queue.
@@ -232,6 +260,33 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   bool _buildWithStyle(NodeStyle style, [NodeStyle? parent]) =>
       !((parent ?? _nearestCollection()).isIncompatible(style));
 
+  /// Visits a recursive [object] and tracks the object's state.
+  void _visitRecursiveCandidate<T>(
+    T object, {
+    required void Function(String recursiveAnchor, T object) visit,
+    String? anchorOnVisit,
+    Iterable<String>? comments,
+    CommentStyle? commentStyle,
+  }) {
+    if (_recursiveTracker[object] case String anchored) {
+      _addNode(
+        ReferenceNode(
+          anchored,
+          comments: comments,
+          commentStyle: commentStyle,
+          recursive: true,
+        ),
+      );
+
+      _typePath.addLast(anchored);
+      return;
+    }
+
+    final anchor = _trackRecursive(object, anchorOnVisit);
+    visit(anchor, object);
+    _recursiveTracker.remove(object);
+  }
+
   @override
   void visitObject(Object? object) => switch (_mapper(object)) {
     DumpableView view => visitView(view),
@@ -251,6 +306,8 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
           commentStyle: alias.commentStyle,
         ),
       );
+
+      _typePath.addLast(ref);
       return;
     }
 
@@ -258,66 +315,80 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   }
 
   @override
-  void visitIterable(Iterable<Object?> iterable) {
-    // TODO: Recursive support when?
-    _buildIterable(
-      iterable,
+  void visitIterable(Iterable<Object?> iterable) => _visitRecursiveCandidate(
+    iterable,
+    visit: (anchor, object) => _buildIterable(
+      object,
       style: _config.iterableStyle,
       localTag: _kindToTag(_config, sequenceTag),
       forceInline: _inlineRules.last,
-    );
-  }
+      recursiveAnchor: anchor,
+    ),
+  );
 
   @override
   void visitIterableView(YamlIterable iterable) {
-    final YamlIterable(:comments, :anchor, :tag, :forceInline, :nodeStyle) =
-        iterable;
+    final YamlIterable(:anchor, :comments, :commentStyle) = iterable;
 
-    _buildIterable(
-      iterable.toFormat(iterable.node),
-      style: nodeStyle,
-      forceInline: forceInline || _inlineRules.last,
+    _visitRecursiveCandidate(
+      iterable.node,
+      anchorOnVisit: _pushAnchor(anchor),
       comments: comments,
-      anchor: _pushAnchor(anchor),
-      commentStyle: iterable.commentStyle,
-      localTag: _localTag(
-        tag,
-        validate: throwIfNotListTag,
-        includeGeneric: _config.includeSchemaTag,
+      commentStyle: commentStyle,
+      visit: (recursive, object) => _buildIterable(
+        iterable.toFormat(object),
+        style: iterable.nodeStyle,
+        forceInline: iterable.forceInline || _inlineRules.last,
+        comments: comments,
+        anchor: anchor,
+        recursiveAnchor: recursive,
+        commentStyle: commentStyle,
+        localTag: _localTag(
+          iterable.tag,
+          validate: throwIfNotListTag,
+          includeGeneric: _config.includeSchemaTag,
+        ),
       ),
     );
   }
 
   @override
-  void visitMap(Map<Object?, Object?> map) {
-    // TODO: Recursive support when?
-    _buildMap(
-      map.entries,
+  void visitMap(Map<Object?, Object?> map) => _visitRecursiveCandidate(
+    map,
+    visit: (anchor, object) => _buildMap(
+      object.entries,
       style: _config.mapStyle,
       localTag: _kindToTag(_config, mappingTag),
       forceInline: _inlineRules.last,
-    );
-  }
+      recursiveAnchor: anchor,
+    ),
+  );
 
   @override
   void visitMappingView(YamlMapping mapping) {
-    final YamlMapping(:comments, :anchor, :tag, :forceInline, :nodeStyle) =
-        mapping;
+    final YamlMapping(:anchor, :comments, :commentStyle) = mapping;
 
-    _buildMap(
-      LinkedHashSet<MapEntry<Object?, Object?>>(
-        equals: (p0, p1) => p0.key == p1.key,
-        hashCode: (p0) => p0.key.hashCode,
-      )..addAll(mapping.toFormat(mapping.node)),
-      style: nodeStyle,
-      forceInline: forceInline || _inlineRules.last,
+    _visitRecursiveCandidate(
+      mapping.node,
+      anchorOnVisit: _pushAnchor(anchor),
       comments: comments,
-      anchor: _pushAnchor(anchor),
-      commentStyle: mapping.commentStyle,
-      localTag: _localTag(
-        tag,
-        validate: throwIfNotMapTag,
-        includeGeneric: _config.includeSchemaTag,
+      commentStyle: commentStyle,
+      visit: (recursive, object) => _buildMap(
+        LinkedHashSet<MapEntry<Object?, Object?>>(
+          equals: (p0, p1) => p0.key == p1.key,
+          hashCode: (p0) => p0.key.hashCode,
+        )..addAll(mapping.toFormat(object)),
+        style: mapping.nodeStyle,
+        forceInline: mapping.forceInline || _inlineRules.last,
+        comments: comments,
+        anchor: anchor,
+        recursiveAnchor: recursive,
+        commentStyle: commentStyle,
+        localTag: _localTag(
+          mapping.tag,
+          validate: throwIfNotMapTag,
+          includeGeneric: _config.includeSchemaTag,
+        ),
       ),
     );
   }
@@ -403,6 +474,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     YamlIterableEntry iterable, {
     required NodeStyle style,
     required bool forceInline,
+    required String? recursiveAnchor,
     List<String>? comments,
     String? anchor,
     String? localTag,
@@ -425,6 +497,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     comments: comments,
     commentStyle: commentStyle,
     anchor: anchor,
+    recursiveAnchor: recursiveAnchor,
     localTag: localTag,
     type: NodeType.list,
   );
@@ -433,6 +506,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   void _buildMap(
     YamlMappingEntry iterable, {
     required NodeStyle style,
+    required String? recursiveAnchor,
     bool forceInline = false,
     List<String>? comments,
     String? anchor,
@@ -457,6 +531,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     comments: comments,
     commentStyle: commentStyle,
     anchor: anchor,
+    recursiveAnchor: recursiveAnchor,
     localTag: localTag,
     type: NodeType.map,
   );
@@ -472,6 +547,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     required bool forceInline,
     required List<String>? comments,
     required String? anchor,
+    required String? recursiveAnchor,
     required String? localTag,
     required CommentStyle? commentStyle,
     required NodeType type,
@@ -485,8 +561,12 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     _typePath.add('[${type.toString().capFirst()}]');
 
     var spanMultipleLines = buildStyle.isBlock;
+    var hasRecursiveRef = false;
 
-    void update(bool isMultiline) {
+    void update(bool isMultiline, T child) {
+      hasRecursiveRef =
+          hasRecursiveRef ||
+          isRecursiveAnchorRef(child, anchor ?? recursiveAnchor);
       if (forceInline) return;
       spanMultipleLines = spanMultipleLines || isMultiline;
     }
@@ -496,7 +576,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     for (final (index, element) in iterable.indexed) {
       iterate(index, element);
       final (isMultiline, node) = compose();
-      update(isMultiline);
+      update(isMultiline, node);
       queue.addLast(node);
     }
 
@@ -507,7 +587,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
         nodeType: nodeType,
         forcedInline: forceInline,
         isMultiline: spanMultipleLines && queue.isNotEmpty,
-        anchor: anchor,
+        anchor: anchor ?? (hasRecursiveRef ? recursiveAnchor : null),
         localTag: localTag,
         comments: comments,
         commentStyle: commentStyle?.ofQualified(buildStyle),

--- a/packages/dump_yaml/test/recursive_test.dart
+++ b/packages/dump_yaml/test/recursive_test.dart
@@ -1,0 +1,93 @@
+import 'package:checks/checks.dart';
+import 'package:dump_yaml/src/configs.dart';
+import 'package:dump_yaml/src/dumper/yaml_dumper.dart';
+import 'package:dump_yaml/src/views/dumpable.dart';
+import 'package:dump_yaml/src/views/views.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // `package:rookie_yaml` doesn't support recursive aliases yet but we can
+  // simulate them with `DumpableView`s.
+  // TODO: Add more tests.
+  test('Detects and creates an alias for self-referential lists', () {
+    final list = <Object?>['hello', 'there'];
+    list.add(YamlIterable(list)); // cheat
+
+    // Block lists
+    check(
+      dumpAsYaml(list, config: Config.defaults()),
+    ).equals('''
+&recursive
+- hello
+- there
+- *recursive
+''');
+  });
+
+  test('Detects and creates an alias for self-referential maps', () {
+    final map = <String, Object>{'key': 'value'};
+    map['self'] = YamlMapping(map);
+
+    // Block maps
+    check(dumpAsYaml(map, config: Config.defaults())).equals('''
+&recursive
+key: value
+self: *recursive
+''');
+  });
+
+  test("Detects and uses a view's anchor for self-referential objects", () {
+    final map = <String, Object>{};
+    map['self'] = YamlMapping(map);
+
+    final list = <Object?>['hello'];
+
+    list
+      ..add(list)
+      ..add(YamlMapping(map)..anchor = 'map');
+
+    map['iter'] = list;
+
+    check(dumpAsYaml(YamlIterable(list)..anchor = 'iter')).equals('''
+&iter
+- hello
+- *iter
+- &map
+  self: *map
+  iter: *iter
+''');
+  });
+
+  test("Preserves a recursive object's view properties", () {
+    final list = <Object?>[];
+
+    list
+      ..add(
+        YamlIterable(list)
+          ..comments.addAll(['block', 'comments'])
+          ..commentStyle = CommentStyle.block,
+      )
+      ..add(
+        YamlIterable(list)
+          ..comments.addAll(['possessive', 'comments'])
+          ..commentStyle = CommentStyle.possessive,
+      )
+      ..add(
+        YamlIterable(list)
+          ..comments.addAll(['trailing', 'comments'])
+          ..commentStyle = CommentStyle.trailing,
+      );
+
+    check(dumpAsYaml(list)).equals('''
+&recursive
+# block
+# comments
+- *recursive
+- # possessive
+  # comments
+  *recursive
+- *recursive # trailing
+             # comments
+''');
+  });
+}

--- a/packages/dump_yaml/test/tree_builder_test.dart
+++ b/packages/dump_yaml/test/tree_builder_test.dart
@@ -106,6 +106,21 @@ void main() {
         ..hasTag(null);
     });
 
+    test('Removes duplicates from a custom YamlMapping', () {
+      treeBuilder.buildFor(
+        YamlMapping(
+          [('sneaky', 'entry'), ('sneaky', 'entry')],
+          toFormat: (object) => (object as List<(String, String)>).map(
+            (e) => MapEntry(e.$1, e.$2),
+          ),
+        ),
+      );
+
+      check(
+        treeBuilder.builtNode(),
+      ).isA<MapNode>().whoseNode().length.equals(1);
+    });
+
     test('Throws if tags are mismatched', () {
       check(
         () => treeBuilder.buildFor(ScalarView('')..withNodeTag(mappingTag)),


### PR DESCRIPTION
This PR:

- Fixes an issue where the dumper failed to catch duplicate keys while building the representation tree.
- Adds support for detecting recursive objects:
    - Recursive objects can be introduced via `DumpableView`s
    - YAML supports recursive aliases. Other parsers may have this feature but I haven't implemented it in `package:rookie_yaml` (yet).