### PR TITLE
fix(parser): tighten grammar eval conditions

### DIFF
--- a/packages/rookie_yaml/lib/src/parser/document/document_events.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/document_events.dart
@@ -96,6 +96,20 @@ enum FlowCollectionEvent implements ParserEvent {
   bool get isFlowContext => true;
 }
 
+ScalarEvent _expectNsCharAfter(SourceIterator iterator, int? charAfter) {
+  if (charAfter.isNotNullAnd((e) => e.isNonSpaceChar())) {
+    return ScalarEvent.startFlowPlain;
+  }
+
+  throwWithSingleOffset(
+    iterator,
+    message:
+        '"${iterator.current.asString()}" must be followed by a non-space '
+        'character when used as the first char of plain scalar.',
+    offset: iterator.currentLineInfo.current,
+  );
+}
+
 /// Infers a generalized [ParserEvent] that determines how the [DocumentParser]
 /// should parse the next collection of characters.
 ParserEvent inferNextEvent(
@@ -112,52 +126,97 @@ ParserEvent inferNextEvent(
     (c) => c.isWhiteSpace() || c.isLineBreak(),
   );
 
-  return switch (iterator.current) {
-    doubleQuote => ScalarEvent.startFlowDoubleQuoted,
-    singleQuote => ScalarEvent.startFlowSingleQuoted,
-    literal => ScalarEvent.startBlockLiteral,
-    folded => ScalarEvent.startBlockFolded,
+  switch (iterator.current) {
+    case doubleQuote:
+      return ScalarEvent.startFlowDoubleQuoted;
 
-    mappingValue when isBlockContext && canBeSeparation =>
-      BlockCollectionEvent.startEntryValue,
+    case singleQuote:
+      return ScalarEvent.startFlowSingleQuoted;
 
-    // Flow node doesn't need the space when key is json-like (double quoted)
-    mappingValue
-        when !isBlockContext &&
-            (canBeSeparation ||
-                lastKeyWasJsonLike ||
-                charAfter.isNotNullAnd((c) => c.isFlowDelimiter())) =>
-      FlowCollectionEvent.startEntryValue,
+    // |
+    case literal:
+      return ScalarEvent.startBlockLiteral;
 
-    blockSequenceEntry when canBeSeparation =>
-      BlockCollectionEvent.startBlockListEntry,
+    // >
+    case folded:
+      return ScalarEvent.startBlockFolded;
 
-    mappingKey when isBlockContext && canBeSeparation =>
-      BlockCollectionEvent.startExplicitKey,
+    case flowSequenceStart:
+      return FlowCollectionEvent.startFlowSequence;
+    case flowSequenceEnd:
+      return FlowCollectionEvent.endFlowSequence;
+    case flowEntryEnd:
+      return FlowCollectionEvent.nextFlowEntry;
+    case mappingStart:
+      return FlowCollectionEvent.startFlowMap;
+    case mappingEnd:
+      return FlowCollectionEvent.endFlowMap;
 
-    // In flow collections, it is allow a "?" to occur separately without any
-    // key beside a "," or "{" or "}" or "[" or "]"
-    mappingKey
-        when !isBlockContext &&
-            (canBeSeparation ||
-                charAfter.isNotNullAnd((c) => c.isFlowDelimiter())) =>
-      FlowCollectionEvent.startExplicitKey,
-
-    flowSequenceStart => FlowCollectionEvent.startFlowSequence,
-    flowSequenceEnd => FlowCollectionEvent.endFlowSequence,
-    flowEntryEnd => FlowCollectionEvent.nextFlowEntry,
-    mappingStart => FlowCollectionEvent.startFlowMap,
-    mappingEnd => FlowCollectionEvent.endFlowMap,
-
-    anchor => NodePropertyEvent.startAnchor,
-    alias => NodePropertyEvent.startAlias,
-    tag =>
-      charAfter == verbatimStart
+    case anchor:
+      return NodePropertyEvent.startAnchor;
+    case alias:
+      return NodePropertyEvent.startAlias;
+    case tag:
+      return charAfter == verbatimStart
           ? NodePropertyEvent.startVerbatimTag
-          : NodePropertyEvent.startTag,
+          : NodePropertyEvent.startTag;
 
-    _ => ScalarEvent.startFlowPlain,
-  };
+    case mappingValue:
+      {
+        // key: value
+        if (canBeSeparation) {
+          return isBlockContext
+              ? BlockCollectionEvent.startEntryValue
+              : FlowCollectionEvent.startEntryValue;
+        } else if (!isBlockContext &&
+            (lastKeyWasJsonLike ||
+                charAfter.isNotNullAnd((c) => c.isFlowDelimiter()))) {
+          // JSON-like structures can omit the space.
+          return FlowCollectionEvent.startEntryValue;
+        }
+
+        return _expectNsCharAfter(iterator, charAfter);
+      }
+
+    case blockSequenceEntry:
+      {
+        if (isBlockContext) {
+          return canBeSeparation
+              ? BlockCollectionEvent.startBlockListEntry
+              : _expectNsCharAfter(iterator, charAfter);
+        } else if (charAfter.isNotNullAnd(
+          (e) => !e.isFlowDelimiter() && e.isNonSpaceChar(),
+        )) {
+          // ns-plain-safe-in
+          return ScalarEvent.startFlowPlain;
+        }
+
+        // This character is not allow in a flow context.
+        throwWithSingleOffset(
+          iterator,
+          message: '"-" cannot be used in a flow context.',
+          offset: iterator.currentLineInfo.current,
+        );
+      }
+
+    // ?
+    case mappingKey:
+      {
+        if (canBeSeparation) {
+          return isBlockContext
+              ? BlockCollectionEvent.startExplicitKey
+              : FlowCollectionEvent.startExplicitKey;
+        } else if (!isBlockContext &&
+            charAfter.isNotNullAnd((c) => c.isFlowDelimiter())) {
+          return FlowCollectionEvent.startExplicitKey;
+        }
+
+        return _expectNsCharAfter(iterator, charAfter);
+      }
+
+    default:
+      return ScalarEvent.startFlowPlain;
+  }
 }
 
 /// Infers the next block event.

--- a/packages/rookie_yaml/lib/src/parser/document/node_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/node_utils.dart
@@ -300,9 +300,11 @@ bool exitBlockCollection<Obj, T extends NodeDelegate<Obj>>(
 
   void updateEnd(RuneOffset end) => collection.nodeSpan.parsingEnd = end;
 
-  if (iterator.isEOF || exitIndent == null) {
+  final parsedEnd = iterator.isEOF || exitIndent == null;
+
+  if (parsedEnd) {
     updateEnd(lineInfo.current);
-    return iterator.isEOF;
+    return parsedEnd;
   } else if (marker.stopIfParsingDoc) {
     updateEnd(lineInfo.start);
     return true;

--- a/packages/rookie_yaml/lib/src/parser/parser_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/parser_utils.dart
@@ -283,7 +283,10 @@ int? skipToParsableChar(
         skipWhitespace(iterator, skipTabs: true);
         iterator.nextChar();
 
-      case comment:
+      case comment
+          when iterator.before.isNullOr(
+            (c) => c.isWhiteSpace() || c.isLineBreak(),
+          ):
         {
           final (:onExit, :comment) = parseComment(iterator);
           onParseComment(comment);

--- a/packages/rookie_yaml/test/flow_collections_test.dart
+++ b/packages/rookie_yaml/test/flow_collections_test.dart
@@ -269,9 +269,7 @@ implicit: pair,
     block
 ]
           ''').parseNodeSingle(),
-          ).throwsParserException(
-            'Block nodes are not allowed in flow collections',
-          );
+          ).throws();
         }
       },
     );


### PR DESCRIPTION
This PR improves some issues I missed while refactoring some sections prior to `v0.6.0` release:

- Ensures the parser exits as intended when a block collection cannot be parsed further.
- Refactors and tightens the threshold for defaulting to `ScalarStyle.plain`.
- Fixes an issue where `skipToParsableChar` never checked if a comment's `#` was preceded by a whitespace/line break char.