### PR TITLE
refactor(dumper): rework `YamlMapping` converter

### DIFF
--- a/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
+++ b/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
@@ -6,26 +6,7 @@ import 'package:dump_yaml/src/event_tree/scalar_content.dart';
 import 'package:dump_yaml/src/event_tree/visitor.dart';
 import 'package:dump_yaml/src/views/dumpable.dart';
 import 'package:dump_yaml/src/views/views.dart';
-import 'package:rookie_yaml/rookie_yaml.dart'
-    show
-        GlobalTag,
-        NodeStyle,
-        ResolvedTag,
-        ScalarStyle,
-        TagHandle,
-        TagHandleVariant,
-        TagShorthand,
-        booleanTag,
-        floatTag,
-        integerTag,
-        mappingTag,
-        nullTag,
-        resolvedTagInfo,
-        sequenceTag,
-        stringTag,
-        throwIfNotListTag,
-        throwIfNotMapTag,
-        throwIfNotScalarTag;
+import 'package:rookie_yaml/rookie_yaml.dart';
 
 extension on String {
   String capFirst() =>
@@ -384,10 +365,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
       comments: comments,
       commentStyle: commentStyle,
       visit: (recursive, object) => _buildMap(
-        LinkedHashSet<MapEntry<Object?, Object?>>(
-          equals: (p0, p1) => p0.key == p1.key,
-          hashCode: (p0) => p0.key.hashCode,
-        )..addAll(mapping.toFormat(object)),
+        mapping.toFormat(object),
         style: mapping.nodeStyle,
         forceInline: mapping.forceInline || _inlineRules.last,
         comments: comments,

--- a/packages/dump_yaml/lib/src/views/views.dart
+++ b/packages/dump_yaml/lib/src/views/views.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:dump_yaml/src/views/dumpable.dart';
 import 'package:rookie_yaml/rookie_yaml.dart';
 
@@ -50,10 +52,29 @@ typedef MapToYaml = ObjectFromView<YamlMappingEntry>;
 
 /// Obtains the entries of the [object]. If not a map, the [object] is treated
 /// as a key with a null value.
-YamlMappingEntry mapping(Object? object) =>
-    object is Map ? object.entries : [MapEntry(object, null)];
+YamlMappingEntry _mapping(Object? object) {
+  MapEntry<Object?, Object?> wrap(Object? toWrap) =>
+      toWrap is MapEntry ? toWrap : MapEntry(toWrap, null);
+
+  return switch (object) {
+    Map() => object.entries,
+    Iterable() => object.fold(
+      LinkedHashSet(
+        equals: (k1, k2) => yamlCollectionEquality.equals(k1.key, k2.key),
+        hashCode: (p0) => yamlCollectionEquality.hash(p0.key),
+      ),
+      (buff, next) {
+        (buff as LinkedHashSet).add(wrap(next));
+        return buff;
+      },
+    ),
+    _ => [wrap(object)],
+  };
+}
 
 /// A mutable view for a [Map]-like object that can have YAML node properties.
+/// Unlike [ScalarView] and [YamlIterable], its `toFormat` getter cannot be
+/// overriden due to the sensitive nature of yaml [Map]s.
 ///
 /// {@category dumpable_view}
 /// {@category dump_map}
@@ -65,13 +86,13 @@ final class YamlMapping extends ConcreteNode<YamlMappingEntry> {
   /// callback that will be called when the map is being dumped.
   ///
   /// This view inherits the [node]'s hashcode and equality implementation.
-  YamlMapping(super.node, {this.toFormat = mapping});
+  YamlMapping(super.node);
 
   @override
   NodeStyle nodeStyle = NodeStyle.block;
 
   @override
-  MapToYaml toFormat;
+  MapToYaml get toFormat => _mapping;
 }
 
 /// Maps any object to a scalar.

--- a/packages/dump_yaml/test/map_test.dart
+++ b/packages/dump_yaml/test/map_test.dart
@@ -382,11 +382,11 @@ key: 24
   });
 
   group('Key tests', () {
+    setUp(() => dumper.reset());
+
     test(
       'Converts implicit key if length is greater than 1024 unicode characters',
       () {
-        dumper.reset();
-
         final explicit = _randomImplicitKey(1025);
         final implicit = _randomImplicitKey(1024);
         dumper.dump({explicit: 'explicit', implicit: 'implicit'});
@@ -403,8 +403,6 @@ key: 24
       'Converst alias to explicit if length is greater than 1024 unicode '
       'characters',
       () {
-        dumper.reset();
-
         final anchor = _randomImplicitKey(1100);
         final key = ScalarView('implicit')..anchor = anchor;
         dumper.dump({key: 'hello', Alias(anchor): 'alias'});

--- a/packages/dump_yaml/test/tree_builder_test.dart
+++ b/packages/dump_yaml/test/tree_builder_test.dart
@@ -108,17 +108,19 @@ void main() {
 
     test('Removes duplicates from a custom YamlMapping', () {
       treeBuilder.buildFor(
-        YamlMapping(
-          [('sneaky', 'entry'), ('sneaky', 'entry')],
-          toFormat: (object) => (object as List<(String, String)>).map(
-            (e) => MapEntry(e.$1, e.$2),
-          ),
-        ),
+        YamlMapping([
+          ('sneaky', 'entry'),
+          ('sneaky', 'entry'),
+          MapEntry(['key'], null),
+          ['key'],
+          {'key': 'value'},
+          {'key': 'value'},
+        ]),
       );
 
       check(
         treeBuilder.builtNode(),
-      ).isA<MapNode>().whoseNode().length.equals(1);
+      ).isA<MapNode>().whoseNode().length.equals(3);
     });
 
     test('Throws if tags are mismatched', () {


### PR DESCRIPTION
This PR:

- Restricts the ability to override or provide a custom mapper since map entry keys are deeply compared.
- Prevents `toFormat` from being mutable.
- Reworks the `mapping` helper and makes it private.