### PR TITLE
fix(parser): ensure a block map always holds the structural offset

### DIFF
--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_map.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_map.dart
@@ -81,7 +81,12 @@ BlockNode<Obj> composeBlockMapFromScalar<Obj>(
     }
   }
 
-  final (keyProp, mapProp) = (keyOrMapProperty?.isMultiline ?? false)
+  // Prefer handing off properties to the map moreso when no properties are
+  // present. The map should hold the structual offset at all times. Not the
+  // key.
+  final (keyProp, mapProp) =
+      keyOrMapProperty != null &&
+          (keyOrMapProperty.isMultiline || !keyOrMapProperty.parsedAny)
       ? (null, keyOrMapProperty)
       : (keyOrMapProperty, null);
 


### PR DESCRIPTION
A block map has no indicators and must be the reference point for any structural anchors related to the collection and not the first key.