### PR TITLE
build(parser): bump yaml test suite runner version

### DIFF
--- a/packages/rookie_yaml/pubspec.yaml
+++ b/packages/rookie_yaml/pubspec.yaml
@@ -36,5 +36,4 @@ dev_dependencies:
   yaml_test_suite_runner:
     git:
       url: https://github.com/kekavc24/yaml_test_suite_runner.git
-      tag_pattern: v{{version}}
-    version: 0.0.5
+      ref: 4d5bf04904be073d5f8aecf40327086a784ba56c


### PR DESCRIPTION
This PR:

- The latest [test suite runner](https://github.com/kekavc24/yaml_test_suite_runner) version fixes some issues where the first test case influenced the status of the next which should not be the case.
- Pins the test suite runner to a specific commit instead of versioning using the `pubspec.yaml` version.