### PR TITLE
fix(parser): accurately skip separation spaces (tabs) in any context

### DIFF
--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_map.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_map.dart
@@ -67,6 +67,7 @@ BlockNode<Obj> composeBlockMapFromScalar<Obj>(
     final indentOrSeparation = skipToParsableChar(
       iterator,
       onParseComment: onParseComment,
+      allowTabs: (currentIndent, _) => currentIndent == null,
     );
 
     // Indent must be null. This must be an inlined key

--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_node.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_node.dart
@@ -179,10 +179,11 @@ BlockNode<Obj> _safeBlockState<Obj>(
   if (!iterator.isEOF &&
       !blockInfo.docMarker.stopIfParsingDoc &&
       (blockInfo.exitIndent == seamlessIndentMarker ||
-          iterator.current == comment)) {
+          iterator.current.matches((i) => i.isWhiteSpace() || i == comment))) {
     final indent = skipToParsableChar(
       iterator,
       onParseComment: state.onParseComment,
+      allowTabs: (currentIndent, hasTabs) => currentIndent == null && !hasTabs,
     );
 
     return (
@@ -285,7 +286,7 @@ BlockNode<Obj> parseBlockNode<Obj>(
   //
   // [*] Can actually degenerate
   //
-  // key:
+  // key: !!map
   //   value: degenerate
   //
   // See [parseImplicitValue]

--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_sequence.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_sequence.dart
@@ -141,6 +141,7 @@ _SequenceState _sequenceNodeOrMarker(
         fixedInlineIndent: inlineFixedIndent,
         forceInlined: false,
         composeImplicitMap: composeMap,
+        canComposeMapIfMultiline: true,
         structuralOffset: indicatorOffset,
       );
 

--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_sequence.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_sequence.dart
@@ -93,9 +93,10 @@ _SequenceState _sequenceNodeOrMarker(
 
     // Be mechanical. Call [parseBlockNode] only after we determine the correct
     // indent range for this node.
-    final indentOrSeparation = skipToParsableChar(
+    final (:indentOrSeparation, :composeMap) = skipToElementStart(
       iterator,
       onParseComment: onParseComment,
+      structuralOffset: indicatorOffset,
     );
 
     final isNextLevel = indentOrSeparation != null;
@@ -139,7 +140,7 @@ _SequenceState _sequenceNodeOrMarker(
         laxBlockIndent: entryIndent,
         fixedInlineIndent: inlineFixedIndent,
         forceInlined: false,
-        composeImplicitMap: true,
+        composeImplicitMap: composeMap,
         structuralOffset: indicatorOffset,
       );
 

--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_wildcard.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/block_wildcard.dart
@@ -122,6 +122,7 @@ BlockNode<Obj> parseFlowNodeInBlock<Obj>(
     ),
   };
 
+  // TODO: isRoot
   final indentOfNextNode = skipToParsableChar(
     state.iterator,
     onParseComment: state.onParseComment,

--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/explicit_block_entry.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/explicit_block_entry.dart
@@ -29,9 +29,10 @@ import 'package:rookie_yaml/src/schema/yaml_node.dart';
 
   iterator.nextChar();
 
-  final indentOrSeparation = skipToParsableChar(
+  final (:indentOrSeparation, :composeMap) = skipToElementStart(
     iterator,
     onParseComment: state.onParseComment,
+    structuralOffset: explicitCharOffset,
   );
 
   final isNextLevel = indentOrSeparation != null;
@@ -97,7 +98,7 @@ import 'package:rookie_yaml/src/schema/yaml_node.dart';
       laxBlockIndent: indent + 1,
       fixedInlineIndent: inlineFixedIndent,
       forceInlined: false,
-      composeImplicitMap: true,
+      composeImplicitMap: composeMap,
       structuralOffset: explicitCharOffset,
     ),
     keyIndent: indent,

--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/explicit_block_entry.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/explicit_block_entry.dart
@@ -99,6 +99,7 @@ import 'package:rookie_yaml/src/schema/yaml_node.dart';
       fixedInlineIndent: inlineFixedIndent,
       forceInlined: false,
       composeImplicitMap: composeMap,
+      canComposeMapIfMultiline: true,
       structuralOffset: explicitCharOffset,
     ),
     keyIndent: indent,

--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/implicit_block_entry.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/implicit_block_entry.dart
@@ -185,7 +185,7 @@ BlockInfo parseImplicitValue<Obj>(
       fixedInlineIndent: valueIndent,
       forceInlined: false,
       composeImplicitMap: hasIndent && composeBlockCollection,
-      canComposeMapIfMultiline: composeBlockCollection,
+      canComposeMapIfMultiline: true,
       structuralOffset: indicatorOffset,
     ),
     keyIndent: keyIndent,

--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/implicit_block_entry.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/implicit_block_entry.dart
@@ -92,22 +92,38 @@ BlockInfo parseImplicitValue<Obj>(
 
   iterator.nextChar();
 
-  /// It's better if we determine the actual state of the value here before
-  /// handing this off to [parseBlockNode]
+  var composeBlockCollection = true;
+
+  // It's better if we determine the actual state of the value here before
+  // handing this off to [parseBlockNode]
   var indentOrSeparation = skipToParsableChar(
     iterator,
     onParseComment: state.onParseComment,
+    allowTabs: (currentIndent, hasTabs) {
+      // We only allow tabs in a context we can control, which is, this key's
+      // value via the [composeBlockCollection] variable. We don't want the
+      // previous parsing context handling a dirty state when Dart unrolls this
+      // recursive context.
+      if (hasTabs) {
+        final isInline = currentIndent == null;
+        composeBlockCollection = isInline;
+        return isInline || currentIndent > keyIndent;
+      }
+
+      return true;
+    },
   );
 
   final hasIndent = indentOrSeparation != null;
   final valueIndent = keyIndent + 1;
+  final event = eventCallback();
 
   // Exit if we cannot parse an implicit value as a block node
   if (hasIndent && indentOrSeparation < valueIndent) {
     // Check if we should exit or recover and parse a block sequence.
     if (iterator.isEOF ||
         indentOrSeparation < keyIndent ||
-        eventCallback() != BlockCollectionEvent.startBlockListEntry) {
+        event != BlockCollectionEvent.startBlockListEntry) {
       onValue(
         nullScalarDelegate(
             indentLevel: keyIndentLevel,
@@ -131,9 +147,10 @@ BlockInfo parseImplicitValue<Obj>(
       onSequence: onValue,
       onNextImplicitEntry: onEntryValue,
     ).blockInfo;
-  } else if (eventCallback()
+  } else if (event
       case BlockCollectionEvent.startBlockListEntry ||
-          BlockCollectionEvent.startExplicitKey when !hasIndent) {
+          BlockCollectionEvent.startExplicitKey
+      when !hasIndent || !composeBlockCollection) {
     throwWithRangedOffset(
       iterator,
       message:
@@ -167,8 +184,8 @@ BlockInfo parseImplicitValue<Obj>(
       laxBlockIndent: valueIndent,
       fixedInlineIndent: valueIndent,
       forceInlined: false,
-      composeImplicitMap: hasIndent,
-      canComposeMapIfMultiline: true,
+      composeImplicitMap: hasIndent && composeBlockCollection,
+      canComposeMapIfMultiline: composeBlockCollection,
       structuralOffset: indicatorOffset,
     ),
     keyIndent: keyIndent,

--- a/packages/rookie_yaml/lib/src/parser/document/document_parser.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/document_parser.dart
@@ -132,6 +132,7 @@ final class DocumentParser<Doc, R> {
       iterator,
       onParseComment: onParseComment,
       leadingAsIndent: !_state.docStartExplicit,
+      isRoot: true,
     );
 
     iterator.skipBOM();
@@ -176,6 +177,7 @@ final class DocumentParser<Doc, R> {
         iterator,
         onParseComment: onParseComment,
         leadingAsIndent: !isInlineWithMarker,
+        isRoot: true,
       );
 
       _throwIfBlockUnsafe(
@@ -324,10 +326,9 @@ extension<Doc, R> on DocumentParser<Doc, R> {
       return;
     }
 
-    var charBehind = 0;
     final marker = checkForDocumentMarkers(
       iterator,
-      onMissing: (b) => charBehind = b.length,
+      onMissing: null,
       throwIfDocEndInvalid: true,
     );
 
@@ -337,13 +338,11 @@ extension<Doc, R> on DocumentParser<Doc, R> {
       return;
     }
 
-    throwWithApproximateRange(
+    throwForCurrentLine(
       iterator,
       message:
           'Invalid node state. Expected to find document end "..."'
           ' or directive end chars "---" ',
-      current: iterator.currentLineInfo.current,
-      charCountBefore: iterator.hasNext ? max(charBehind - 1, 0) : charBehind,
     );
   }
 

--- a/packages/rookie_yaml/lib/src/parser/document/document_parser.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/document_parser.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:rookie_yaml/src/parser/delegates/object_delegate.dart';
 import 'package:rookie_yaml/src/parser/directives/directives.dart';
 import 'package:rookie_yaml/src/parser/document/block_nodes/block_node.dart';

--- a/packages/rookie_yaml/lib/src/parser/document/node_properties.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/node_properties.dart
@@ -212,7 +212,16 @@ ParsedProperty _corePropertyParser(
   bool isMultiline() => lfCount > 0;
 
   void skipAndTrackLF() {
-    indentOnExit = skipToParsableChar(iterator, onParseComment: onParseComment);
+    indentOnExit = skipToParsableChar(
+      iterator,
+      onParseComment: onParseComment,
+      allowTabs: (currentIndent, _) {
+        final isSeparation = currentIndent == null;
+        return isBlockContext
+            ? isSeparation
+            : isSeparation || currentIndent >= minIndent;
+      },
+    );
     if (indentOnExit != null) ++lfCount;
   }
 
@@ -416,7 +425,8 @@ ConcreteProperty parseFlowProperties(
     }
   }
 
-  // Move to the next parsable non-ws char
+  // Move to the next parsable non-ws char.
+  // TODO: 50/50 with [nextSafeLineInFlow]. Test this.
   throwIfLessIndent(
     skipToParsableChar(iterator, onParseComment: onParseComment),
   );

--- a/packages/rookie_yaml/lib/src/parser/document/node_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/node_utils.dart
@@ -78,7 +78,12 @@ bool nextSafeLineInFlow(
   required bool forceInline,
   required void Function(YamlComment comment) onParseComment,
 }) {
-  final indent = skipToParsableChar(iterator, onParseComment: onParseComment);
+  final indent = skipToParsableChar(
+    iterator,
+    onParseComment: onParseComment,
+    allowTabs: (currentIndent, _) =>
+        currentIndent == null || currentIndent >= minIndent,
+  );
 
   if (indent != null) {
     // Must not have line breaks

--- a/packages/rookie_yaml/lib/src/parser/parser_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/parser_utils.dart
@@ -406,7 +406,7 @@ BlockElementInfo _skipToBlockElementChar(
 
   if (compose) {
     return (indentOrSeparation: indent, composeMap: true);
-  } else if (inferBlockEvent(iterator) case BlockCollectionEvent()) {
+  } else if (inferBlockEvent(iterator) is BlockCollectionEvent) {
     throwWithRangedOffset(
       iterator,
       message:

--- a/packages/rookie_yaml/lib/src/parser/parser_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/parser_utils.dart
@@ -1,4 +1,5 @@
 import 'package:rookie_yaml/src/parser/directives/directives.dart';
+import 'package:rookie_yaml/src/parser/document/document_events.dart';
 import 'package:rookie_yaml/src/parser/document/scalars/block/block_scalar.dart';
 import 'package:rookie_yaml/src/scanner/encoding/character_encoding.dart';
 import 'package:rookie_yaml/src/scanner/source_iterator.dart';
@@ -338,4 +339,83 @@ int? skipToParsableChar(
   }
 
   return indent;
+}
+
+typedef BlockElementInfo = ({int? indentOrSeparation, bool composeMap});
+
+/// Skips to the next parsable content of a block collection's element.
+///
+/// This function should be called when looking past a block collection's
+/// explicit indicator. The indicator's offset is represented by the
+/// [structuralOffset].
+BlockElementInfo skipToElementStart(
+  SourceIterator iterator, {
+  required void Function(YamlComment comment) onParseComment,
+  required RuneOffset structuralOffset,
+}) {
+  if (iterator.current != space) {
+    return _skipToBlockElementChar(
+      iterator,
+      onParseComment: onParseComment,
+      structuralOffset: structuralOffset,
+    );
+  }
+
+  skipWhitespace(iterator);
+  iterator.nextChar();
+
+  if (iterator.current.matches(
+    (i) => i == tab || i.isLineBreak() || i == comment,
+  )) {
+    return _skipToBlockElementChar(
+      iterator,
+      onParseComment: onParseComment,
+      structuralOffset: structuralOffset,
+    );
+  }
+
+  return (indentOrSeparation: null, composeMap: true);
+}
+
+/// Skips any comments and linebreaks until a character that can be parsed
+/// is encountered. Returns `null` if no indent was found.
+///
+/// This function treats tabs as separation and should be called when parsing
+/// nested block nodes. In such cases, YAML expects the tab to followed by a
+/// line break or more whitespace leading to a line break. Anything else is
+/// invalid YAML grammar.
+BlockElementInfo _skipToBlockElementChar(
+  SourceIterator iterator, {
+  required void Function(YamlComment comment) onParseComment,
+  required RuneOffset structuralOffset,
+}) {
+  var compose = true;
+
+  final indent = skipToParsableChar(
+    iterator,
+    onParseComment: onParseComment,
+    allowTabs: (currentIndent, hasTabs) {
+      if (hasTabs) {
+        compose = false;
+        return currentIndent == null; // Inlined
+      }
+
+      return true;
+    },
+  );
+
+  if (compose) {
+    return (indentOrSeparation: indent, composeMap: true);
+  } else if (inferBlockEvent(iterator) case BlockCollectionEvent()) {
+    throwWithRangedOffset(
+      iterator,
+      message:
+          'Tabs cannot be used as separation spaces between block collection '
+          'indicators',
+      start: structuralOffset,
+      end: iterator.currentLineInfo.current,
+    );
+  }
+
+  return (indentOrSeparation: indent, composeMap: false);
 }

--- a/packages/rookie_yaml/lib/src/parser/parser_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/parser_utils.dart
@@ -283,11 +283,21 @@ int? skipToParsableChar(
         skipWhitespace(iterator, skipTabs: true);
         iterator.nextChar();
 
-      case comment
-          when iterator.before.isNullOr(
-            (c) => c.isWhiteSpace() || c.isLineBreak(),
-          ):
+      case comment:
         {
+          if (!iterator.before.isNullOr(
+            (c) => c.isWhiteSpace() || c.isLineBreak(),
+          )) {
+            throwWithApproximateRange(
+              iterator,
+              message:
+                  'A comment indicator must be the first possible char or be '
+                  'preceded by a whitespace/line break',
+              current: iterator.currentLineInfo.current,
+              charCountBefore: 1,
+            );
+          }
+
           final (:onExit, :comment) = parseComment(iterator);
           onParseComment(comment);
 

--- a/packages/rookie_yaml/lib/src/parser/parser_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/parser_utils.dart
@@ -232,38 +232,42 @@ DocumentMarker checkForDocumentMarkers(
 /// Skips any comments and linebreaks until a character that can be parsed
 /// is encountered. Returns `null` if no indent was found.
 ///
-/// If [leadingAsIndent] is `true`, leading white spaces are treated as indent
-/// as though the previous character.
+/// If [leadingAsIndent] is `true`, leading white spaces are treated as indent.
 ///
-/// You must provide either [comments] or an [onParseComment] [Function]
+/// If [isRoot] is `false` and a call to [allowTabs] with the current indent
+/// returns `false`, an [Exception] is thrown. This is because the tabs are
+/// treated as separation and the parser expects a line break or comment after
+/// any whitespace grouped with the tab.
 int? skipToParsableChar(
   SourceIterator iterator, {
   required void Function(YamlComment comment) onParseComment,
   bool leadingAsIndent = false,
+  bool isRoot = false,
+  bool Function(int? currentIndent, bool hasTabs)? allowTabs,
 }) {
+  final allowAsSeparation = allowTabs ?? (_, _) => true;
   int? indent;
 
-  var warmUp = true;
-
   void checkIndent() {
+    if (iterator.current != space) {
+      indent = 0;
+      return;
+    }
+
     indent = takeFromIteratorUntil(
       iterator,
-      includeCharAtCursor: warmUp && iterator.current == space,
-      mapper: (c) => c,
+      includeCharAtCursor: true,
+      mapper: (t) => t,
       onMapped: (_) {},
-      stopIf: (_, possibleNext) => !possibleNext.isIndent(),
+      stopIf: (_, next) => !next.isIndent(),
     );
 
-    if (iterator.isEOF) return;
-
     iterator.nextChar();
-    warmUp = false;
+    indent = iterator.isEOF ? null : indent;
+  }
 
-    if (leadingAsIndent) return;
-
-    if (iterator.current == tab) {
-      skipWhitespace(iterator, skipTabs: true);
-    }
+  if (leadingAsIndent && iterator.current == space) {
+    checkIndent();
   }
 
   skipper:
@@ -272,16 +276,39 @@ int? skipToParsableChar(
       case carriageReturn || lineFeed:
         {
           skipCrIfPossible(iterator.current, iterator: iterator);
+          iterator.nextChar();
           checkIndent();
         }
 
-      // Check if leading whitespace can be indent
-      case space when leadingAsIndent:
-        checkIndent();
+      case space || tab:
+        {
+          var hasTabs = iterator.current == tab;
 
-      case space || tab when !leadingAsIndent:
-        skipWhitespace(iterator, skipTabs: true);
-        iterator.nextChar();
+          skipWhitespace(
+            iterator,
+            skipTabs: true,
+            hasTabs: () => hasTabs = true,
+          );
+
+          iterator.nextChar();
+
+          final char = iterator.current;
+
+          // Tabs are strictly used for separation.
+          if (iteratedIsEOF(char)) {
+            indent = null;
+            break skipper;
+          } else if (char.matches((c) => c.isLineBreak() || c == comment)) {
+            break;
+          } else if (!isRoot && !allowAsSeparation(indent, hasTabs)) {
+            throwForCurrentLine(
+              iterator,
+              message:
+                  'Spaces/tabs cannot be used here as indent before the current'
+                  ' node',
+            );
+          }
+        }
 
       case comment:
         {

--- a/packages/rookie_yaml/lib/src/scanner/source_iterator.dart
+++ b/packages/rookie_yaml/lib/src/scanner/source_iterator.dart
@@ -359,13 +359,32 @@ List<int> skipWhitespace(
   bool skipTabs = false,
   int? max,
   List<int>? previouslyRead,
+  void Function()? hasTabs,
 }) {
   final buffer = previouslyRead ?? [];
   final hasMax = max != null;
+  final callTabs = hasTabs ?? () {};
+
+  var tabCount = 0;
 
   bool isMatch(int? char) {
-    if (char == null) return false;
-    return skipTabs ? char.isWhiteSpace() : char.isIndent();
+    switch (char) {
+      case tab:
+        {
+          if (skipTabs) {
+            ++tabCount;
+            return true;
+          }
+
+          return false;
+        }
+
+      case space:
+        return true;
+
+      default:
+        return false;
+    }
   }
 
   while (iterator.hasNext &&
@@ -375,6 +394,7 @@ List<int> skipWhitespace(
     buffer.add(iterator.current);
   }
 
+  if (tabCount > 0) callTabs();
   return buffer;
 }
 

--- a/packages/rookie_yaml/test/block_collections_test.dart
+++ b/packages/rookie_yaml/test/block_collections_test.dart
@@ -548,4 +548,82 @@ key:
       );
     });
   });
+
+  group('Grammar adherence', () {
+    test('Tabs as separation in compact collection throws', () {
+      void compactThrows(String yaml) {
+        check(() => loadObject(YamlSource.string(yaml))).throws();
+      }
+
+      compactThrows('-\t- compact');
+      compactThrows('?\t? compact key');
+      compactThrows('-\t? compact map');
+      compactThrows('?\t- compact list');
+    });
+
+    test('Tab separated value never degenerates to map', () {
+      check(
+        loadObject(
+          YamlSource.string(
+            'key:\n'
+            ' \tvalid syntax',
+          ),
+        ),
+      ).isA<Map>().deepEquals({'key': 'valid syntax'});
+
+      check(
+        () => loadObject(
+          YamlSource.string(
+            'key:\n'
+            ' \tcannot: form-nested-map',
+          ),
+        ),
+      ).throws();
+    });
+
+    test('Tabs separated degenerates to map if properties are multiline', () {
+      const map = {'key': 'value'};
+
+      void degenerates<T>(
+        String yaml,
+        void Function(Subject<T> object) checker,
+      ) {
+        checker(check(loadObject(YamlSource.string(yaml))));
+      }
+
+      degenerates(
+        '?\t!!map\n'
+        '  key: value',
+        (obj) => obj.isA<Map>().deepEquals({map: null}),
+      );
+
+      degenerates(
+        '-\t!!map\n'
+        '  key: value',
+        (obj) => obj.isA<List>().deepEquals([map]),
+      );
+
+      degenerates(
+        'implicit:\n'
+        '  \t!!map\n'
+        ' key: value',
+        (obj) => obj.isA<Map>().deepEquals({'implicit': map}),
+      );
+    });
+
+    test(
+      'Throws when dangling tabs results in an invalid block node state',
+      () {
+        check(
+          () => loadObject(
+            YamlSource.string('''
+key: 
+  nested: value
+ \ttab: key 
+'''),
+          ),
+        ).throws();
+      },
+    );
+  });
 }

--- a/packages/rookie_yaml/test/document_test.dart
+++ b/packages/rookie_yaml/test/document_test.dart
@@ -410,11 +410,11 @@ My node starts here
     });
 
     test('Skips leading whitespace as', () {
-      const yaml = ' My node starts here';
+      final scanner = UnicodeIterator.ofString(' My node starts here');
 
-      final scanner = UnicodeIterator.ofString(yaml);
-
-      check(skipToParsableChar(scanner, onParseComment: (_) {})).isNull();
+      check(
+        skipToParsableChar(scanner, onParseComment: (_) {}, isRoot: true),
+      ).isNull();
       check(scanner.current.asString()).equals('M');
     });
 

--- a/packages/rookie_yaml/test/document_test.dart
+++ b/packages/rookie_yaml/test/document_test.dart
@@ -1,11 +1,6 @@
 import 'package:checks/checks.dart';
-import 'package:rookie_yaml/src/parser/directives/directives.dart';
+import 'package:rookie_yaml/rookie_yaml.dart';
 import 'package:rookie_yaml/src/parser/parser_utils.dart';
-import 'package:rookie_yaml/src/scanner/encoding/character_encoding.dart';
-import 'package:rookie_yaml/src/scanner/source_iterator.dart';
-import 'package:rookie_yaml/src/schema/schema.dart';
-import 'package:rookie_yaml/src/schema/yaml_comment.dart';
-import 'package:rookie_yaml/src/schema/yaml_node.dart';
 import 'package:test/test.dart';
 
 import 'helpers/bootstrap_parser.dart';
@@ -438,6 +433,12 @@ My node starts here
         'This is a comment',
         'This is another',
       ]);
+    });
+
+    test('Throws if comments are not preceded by whitespace', () {
+      check(
+        () => loadObject(YamlSource.string('[element, key,# comment]')),
+      ).throws();
     });
   });
 }

--- a/packages/rookie_yaml/test/flow_collections_test.dart
+++ b/packages/rookie_yaml/test/flow_collections_test.dart
@@ -1,4 +1,5 @@
 import 'package:checks/checks.dart';
+import 'package:rookie_yaml/src/loaders/loader.dart';
 import 'package:test/test.dart';
 
 import 'helpers/bootstrap_parser.dart';
@@ -273,5 +274,19 @@ implicit: pair,
         }
       },
     );
+
+    test('Throws when tabs are used as indent', () {
+      check(
+        () => loadObject(
+          YamlSource.string('''
+key:
+  {key:
+  !!map
+\tnext 
+ }
+'''),
+        ),
+      ).throws();
+    });
   });
 }

--- a/packages/rookie_yaml/test/node_properties_test.dart
+++ b/packages/rookie_yaml/test/node_properties_test.dart
@@ -591,10 +591,6 @@ implicit-2: is-an-error}
 
     test('Throws when a multiline property is less indented than its '
         'block node', () {
-      const message =
-          'A block node cannot be indented more that its'
-          ' properties';
-
       for (final parent in const ['?', '-']) {
         check(
           () => bootstrapDocParser('''
@@ -602,7 +598,7 @@ $parent
   &invalid
     - value
 '''),
-        ).throwsParserException(message);
+        ).throws();
 
         check(
           () => bootstrapDocParser('''
@@ -610,7 +606,7 @@ $parent
   &invalid
     ? value
 '''),
-        ).throwsParserException(message);
+        ).throws();
 
         check(
           () => bootstrapDocParser('''
@@ -619,7 +615,7 @@ $parent
     >
      value
 '''),
-        ).throwsParserException(message);
+        ).throws();
 
         check(
           () => bootstrapDocParser('''
@@ -628,7 +624,7 @@ $parent
     |
       value
 '''),
-        ).throwsParserException(message);
+        ).throws();
       }
     });
 


### PR DESCRIPTION
This PR:

- Prevents tabs from being treated as indent in various contexts.
- Improves parser behavior when handling block collections.