### PR TITLE
fix(parser): prevent explicit value from using invalid grammar

### DIFF
--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/explicit_block_entry.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/explicit_block_entry.dart
@@ -143,12 +143,14 @@ BlockInfo parseExplicitBlockEntry<Obj>(
       start: marker,
       end: iterator.currentLineInfo.current,
     );
-  } else if (ignoreValueIfKey) {
+  } else if (ignoreValueIfKey || keyInfo.exitIndent == null) {
     state.onParseMapKey(key!.parsed());
     onExplicitEntry(key!, null);
     return keyInfo;
-  } else if (keyInfo.exitIndent != null) {
-    if (keyInfo.exitIndent! > entryIndent) {
+  } else {
+    final exitIndent = keyInfo.exitIndent!;
+
+    if (exitIndent > entryIndent) {
       final scanner = state.iterator;
       throwWithRangedOffset(
         scanner,
@@ -156,7 +158,7 @@ BlockInfo parseExplicitBlockEntry<Obj>(
         start: key!.nodeSpan.nodeEnd,
         end: state.iterator.currentLineInfo.current,
       );
-    } else if (keyInfo.exitIndent! < entryIndent) {
+    } else if (exitIndent < entryIndent) {
       state.onParseMapKey(key!.parsed());
       onExplicitEntry(key!, null);
       return keyInfo;

--- a/packages/rookie_yaml/test/block_collections_test.dart
+++ b/packages/rookie_yaml/test/block_collections_test.dart
@@ -559,6 +559,12 @@ key:
       compactThrows('?\t? compact key');
       compactThrows('-\t? compact map');
       compactThrows('?\t- compact list');
+      compactThrows('-\tkey: value');
+      compactThrows('?\tkey: value');
+      compactThrows('''
+? okay: map
+:\terr: map
+''');
     });
 
     test('Tab separated value never degenerates to map', () {


### PR DESCRIPTION
We needed to handle a null indent when parsing explicit entries since a `:` from a scalar that cannot compose a map could trick the parser into parsing an explicit `null` value.

- Caught by `Y79Y-08` in the official YAML test suite.
- Add regression tests.