### PR TITLE
fix(parser): parser improvements

### DIFF
--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/forced_block_map.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/forced_block_map.dart
@@ -63,7 +63,8 @@ BlockNode<Obj> composeBlockMapStrict<Obj>(
             flowProperty: property,
           );
         }
-      case NodePropertyEvent():
+      case NodePropertyEvent propertyEvent
+          when propertyEvent != NodePropertyEvent.startAlias:
         {
           nodeInfo = parseBlockNode(
             state,

--- a/packages/rookie_yaml/lib/src/parser/document/node_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/node_utils.dart
@@ -129,13 +129,16 @@ bool continueToNextEntry(
     onParseComment: onParseComment,
   );
 
-  lastEntrySpan.parsingEnd = iterator.currentLineInfo.current;
-
   if (iterator.current != flowEntryEnd) {
+    lastEntrySpan.parsingEnd = iterator.currentLineInfo.current;
     return false;
   }
 
   iterator.nextChar();
+
+  // Include flow indicator as part of the last entry.
+  lastEntrySpan.parsingEnd = iterator.currentLineInfo.current;
+
   final goToNext = nextSafeLineInFlow(
     iterator,
     minIndent: minIndent,

--- a/packages/rookie_yaml/lib/src/scanner/span.dart
+++ b/packages/rookie_yaml/lib/src/scanner/span.dart
@@ -2,7 +2,7 @@
 ///
 /// `lineIndex` - zero-based line index in the source string.<br>
 /// `columnIndex` - zero-based column index within a line.<br>
-/// `span` - number of bytes/UTF-8 code units in this offset.<br>
+/// `span` - number of UTF-? (8 OR 16) code units in this offset.<br>
 /// `offset` - zero-based index in the source. (after all the surrogates/code
 /// units have been combined).
 typedef RuneOffset = ({int lineIndex, int columnIndex, int span, int offset});
@@ -77,6 +77,22 @@ sealed class NodeSpan {
   /// Unlike [nodeEnd], this may represent the offset past any trailing comments
   /// and empty lines that are not considered part of the node's meaningful
   /// content by the parser.
+  ///
+  /// In flow entries, this points to the character after `,` or `}`
+  /// (when in map) or `]` (when in sequence).
+  ///
+  /// ```yaml
+  /// # The scalar "hello" ends at `]` (exclusive).
+  /// [hello]
+  /// ---
+  /// # This is valid yaml. Ends at `]` (exclusive).
+  /// [hello,]
+  /// ---
+  /// # Ends at `,` (inclusive). So this offset points at the space " ".
+  /// # The "," indicates the start of the next entry and acts as a marker for
+  /// # the previous entry.
+  /// [hello, next]
+  /// ```
   RuneOffset end();
 
   @override

--- a/packages/rookie_yaml/test/block_collections_test.dart
+++ b/packages/rookie_yaml/test/block_collections_test.dart
@@ -101,9 +101,7 @@ key2:
 # - block indicator as indent
 ''';
 
-      check(
-        bootstrapDocParser(yaml).nodeAsSimpleString(),
-      ).equals(
+      check(bootstrapDocParser(yaml).nodeAsSimpleString()).equals(
         {
           null: null,
           'key': null,
@@ -114,6 +112,27 @@ key2:
         }.toString(),
       );
     });
+
+    test(
+      'Uses a block map\'s fast path when an alias follows an anchor for map',
+      () {
+        const yaml = '''
+&hello key: value
+next: &other
+    *hello : value
+
+*other : here
+''';
+
+        check(bootstrapDocParser(yaml).nodeAsSimpleString()).equals(
+          {
+            'key': 'value',
+            'next': {'key': 'value'},
+            {'key': 'value'}: 'here',
+          }.toString(),
+        );
+      },
+    );
 
     test('Throws if duplicate keys are found', () {
       void checkDuplicate(String yaml) {
@@ -623,9 +642,9 @@ key:
         check(
           () => loadObject(
             YamlSource.string('''
-key: 
+key:
   nested: value
- \ttab: key 
+ \ttab: key
 '''),
           ),
         ).throws();


### PR DESCRIPTION
This PR:
- Treats `,` in flow entries as part of the previous node's content. Add this information in the docs.
- Uses a block map fast path when an alias occurs after map's properties.