### PR TITLE
Dumper improvements

### DIFF
--- a/packages/dump_yaml/lib/dump_yaml.dart
+++ b/packages/dump_yaml/lib/dump_yaml.dart
@@ -6,7 +6,8 @@ export 'src/dumper/dumper.dart' show YamlBuffer;
 export 'src/dumper/inline_flow_dumper.dart';
 export 'src/dumper/yaml_dumper.dart';
 export 'src/event_tree/node.dart' hide Doc, isRecursiveAnchorRef;
-export 'src/event_tree/tree_builder.dart' show GTags, PathLogger, TreeBuilder;
+export 'src/event_tree/tree_builder.dart'
+    show InjectState, PathLogger, TreeBuilder;
 export 'src/strings.dart' show Normalized, splitUnfoldScanned;
 export 'src/unfolding.dart';
 export 'src/views/dumpable.dart';

--- a/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
+++ b/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
@@ -635,7 +635,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
 }
 
 /// {@category rep_tree}
-extension GTags on TreeBuilder {
+extension InjectState on TreeBuilder {
   /// Adds the global [tags] if their handles are absent.
   void includeGlobalTags(Iterable<GlobalTag> tags) {
     if (_resetTags) _globalTags.clear();
@@ -655,4 +655,10 @@ extension GTags on TreeBuilder {
     _globalTags.clear();
     includeGlobalTags(tags);
   }
+
+  /// Adds any [anchors] not tracked by this builder.
+  ///
+  /// This method should only be called if you are sure at least one object
+  /// within the tree includes such an anchor in its properties.
+  void includeAnchors(Iterable<String> anchors) => _anchors.addAll(anchors);
 }

--- a/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
+++ b/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
@@ -474,6 +474,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     iterate: (index, element) {
       _pushPath(index.toString());
       visitObject(element);
+      return true;
     },
     compose: () {
       // One in, one out
@@ -500,29 +501,43 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     String? anchor,
     String? localTag,
     CommentStyle? commentStyle,
-  }) => _buildCollection(
-    iterable,
-    style: style,
-    nodeType: NodeType.map,
-    iterate: (_, element) {
-      visitObject(element.key);
-      visitObject(element.value);
-    },
-    compose: () {
-      // Two in, two out
-      final value = _nodes.removeLast();
-      final key = _nodes.removeLast();
-      _popPaths(2);
-      return (key.isMultiline || value.isMultiline, (key, value));
-    },
-    forceInline: forceInline,
-    comments: comments,
-    commentStyle: commentStyle,
-    anchor: anchor,
-    recursiveAnchor: recursiveAnchor,
-    localTag: localTag,
-    type: NodeType.map,
-  );
+  }) {
+    final keysSeen = HashSet<Object?>(
+      equals: yamlCollectionEquality.equals,
+      hashCode: yamlCollectionEquality.hash,
+    );
+
+    _buildCollection(
+      iterable,
+      style: style,
+      nodeType: NodeType.map,
+      iterate: (_, element) {
+        final key = element.key;
+
+        if (!keysSeen.add(key)) {
+          return false;
+        }
+
+        visitObject(key);
+        visitObject(element.value);
+        return true;
+      },
+      compose: () {
+        // Two in, two out
+        final value = _nodes.removeLast();
+        final key = _nodes.removeLast();
+        _popPaths(2);
+        return (key.isMultiline || value.isMultiline, (key, value));
+      },
+      forceInline: forceInline,
+      comments: comments,
+      commentStyle: commentStyle,
+      anchor: anchor,
+      recursiveAnchor: recursiveAnchor,
+      localTag: localTag,
+      type: NodeType.map,
+    );
+  }
 
   /// Builds a collection using its entries in the current [iterable]. [iterate]
   /// and [compose] is called on every element.
@@ -530,7 +545,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     Iterable<E> iterable, {
     required NodeStyle style,
     required NodeType nodeType,
-    required void Function(int index, E element) iterate,
+    required bool Function(int index, E element) iterate,
     required (bool isMultiline, T value) Function() compose,
     required bool forceInline,
     required List<String>? comments,
@@ -562,7 +577,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     final queue = ListQueue<T>();
 
     for (final (index, element) in iterable.indexed) {
-      iterate(index, element);
+      if (!iterate(index, element)) continue;
       final (isMultiline, node) = compose();
       update(isMultiline, node);
       queue.addLast(node);

--- a/packages/dump_yaml/lib/src/views/dumpable.dart
+++ b/packages/dump_yaml/lib/src/views/dumpable.dart
@@ -169,10 +169,8 @@ typedef ObjectFromView<To> = To Function(Object? object);
 /// {@category dump_list}
 /// {@category dump_map}
 abstract base class ConcreteNode<To> extends DumpableView {
-  ConcreteNode(this.node);
-
   /// Object that can be dumped as a node
-  Object? node;
+  Object? get node;
 
   @override
   String? get alias => null;

--- a/packages/dump_yaml/lib/src/views/views.dart
+++ b/packages/dump_yaml/lib/src/views/views.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:dump_yaml/src/views/dumpable.dart';
 import 'package:rookie_yaml/rookie_yaml.dart';
 
@@ -31,68 +29,22 @@ final class YamlIterable extends ConcreteNode<YamlIterableEntry> {
   /// will be called when the iterable is being dumped.
   ///
   /// This view inherits the [node]'s hashcode and equality implementation.
-  YamlIterable(super.node, {this.toFormat = iterable});
+  YamlIterable(this.node, {this.toFormat = iterable});
+
+  @override
+  Object? node;
 
   @override
   NodeStyle nodeStyle = NodeStyle.block;
 
   @override
   IterableToYaml toFormat;
-}
-
-/// A list of [MapEntry]s for a YAML map.
-///
-/// {@category dump_map}
-typedef YamlMappingEntry = Iterable<MapEntry<Object?, Object?>>;
-
-/// Maps a map to a yaml mapping.
-///
-/// {@category dump_map}
-typedef MapToYaml = ObjectFromView<YamlMappingEntry>;
-
-/// Obtains the entries of the [object]. If not a map, the [object] is treated
-/// as a key with a null value.
-YamlMappingEntry _mapping(Object? object) {
-  MapEntry<Object?, Object?> wrap(Object? toWrap) =>
-      toWrap is MapEntry ? toWrap : MapEntry(toWrap, null);
-
-  return switch (object) {
-    Map() => object.entries,
-    Iterable() => object.fold(
-      LinkedHashSet(
-        equals: (k1, k2) => yamlCollectionEquality.equals(k1.key, k2.key),
-        hashCode: (p0) => yamlCollectionEquality.hash(p0.key),
-      ),
-      (buff, next) {
-        (buff as LinkedHashSet).add(wrap(next));
-        return buff;
-      },
-    ),
-    _ => [wrap(object)],
-  };
-}
-
-/// A mutable view for a [Map]-like object that can have YAML node properties.
-/// Unlike [ScalarView] and [YamlIterable], its `toFormat` getter cannot be
-/// overriden due to the sensitive nature of yaml [Map]s.
-///
-/// {@category dumpable_view}
-/// {@category dump_map}
-final class YamlMapping extends ConcreteNode<YamlMappingEntry> {
-  /// Creates a [YamlMapping] wrapping a [node].
-  ///
-  /// If the [node] is not an [Map], the default [toFormat] creates a single
-  /// entry with a key and no value.  For a custom object, provide a [toFormat]
-  /// callback that will be called when the map is being dumped.
-  ///
-  /// This view inherits the [node]'s hashcode and equality implementation.
-  YamlMapping(super.node);
 
   @override
-  NodeStyle nodeStyle = NodeStyle.block;
+  bool operator ==(Object other) => yamlCollectionEquality.equals(node, other);
 
   @override
-  MapToYaml get toFormat => _mapping;
+  int get hashCode => yamlCollectionEquality.hash(node);
 }
 
 /// Maps any object to a scalar.
@@ -109,15 +61,19 @@ String string(Object? object) => object.toString();
 final class ScalarView extends ConcreteNode<String> {
   /// Creates a [ScalarView] wrapping a [node] that is always stringified. The
   /// view inherits the [node]'s hashcode and equality implementation.
-  ScalarView(super.node, {this.toFormat = string});
+  ScalarView(this._scalar, {this.toFormat = string});
+
+  Object? _scalar;
+
+  @override
+  Object? get node => _scalar;
 
   @override
   ScalarToString toFormat;
 
-  @override
-  set node(Object? value) {
+  set scalar(Object? value) {
     if (identical(value, this)) return;
-    super.node = value;
+    _scalar = value;
   }
 
   /// Scalar style associated with this view.
@@ -132,4 +88,110 @@ final class ScalarView extends ConcreteNode<String> {
 
   @override
   String toString() => toFormat(node);
+}
+
+/// A list of [MapEntry]s for a YAML map.
+///
+/// {@category dump_map}
+typedef YamlMappingEntry = Iterable<MapEntry<Object?, Object?>>;
+
+/// Maps a map to a yaml mapping.
+///
+/// {@category dump_map}
+typedef MapToYaml = ObjectFromView<YamlMappingEntry>;
+
+/// A mutable view for a [Map]-like object that can have YAML node properties.
+/// Unlike [ScalarView] and [YamlIterable], its `toFormat` getter cannot be
+/// overriden due to the sensitive nature of yaml [Map]s. See [DartMap] or
+/// [CustomMap].
+///
+/// {@category dumpable_view}
+/// {@category dump_map}
+sealed class YamlMapping<T> extends ConcreteNode<YamlMappingEntry> {
+  /// Creates a [YamlMapping] wrapping a [node].
+  ///
+  /// If the [node] is not an [Map], the default [toFormat] creates a single
+  /// entry with a key and no value.  For a custom object, provide a [toFormat]
+  /// callback that will be called when the map is being dumped.
+  ///
+  /// This view inherits the [node]'s hashcode and equality implementation.
+  YamlMapping(this.node);
+
+  @override
+  covariant T node;
+
+  @override
+  NodeStyle nodeStyle = NodeStyle.block;
+
+  @override
+  MapToYaml get toFormat;
+}
+
+/// A wrapper for built-in `Dart` [Map]s.
+///
+/// {@category dumpable_view}
+/// {@category dump_map}
+final class DartMap extends YamlMapping<Map<Object?, Object?>> {
+  DartMap(super.node) : hashCode = yamlCollectionEquality.hash(node);
+
+  @override
+  set node(Map<Object?, Object?> map) {
+    node = map;
+    hashCode = yamlCollectionEquality.hash(map);
+  }
+
+  @override
+  MapToYaml get toFormat =>
+      (e) => (e as Map).entries;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Map && yamlCollectionEquality.equals(other, node);
+
+  @override
+  int hashCode;
+}
+
+/// Helper that returns the keys of an object.
+///
+/// {@category dump_map}
+typedef GetKeys = Iterable<Object?> Function(Object? object);
+
+/// Helper that reads the value of a key from a `map-like` object.
+///
+/// {@category dump_map}
+typedef GetValue =
+    Object? Function(Object? map, ({Object? key, int index}) current);
+
+/// Lazily extracts the entries of an object [v] using predefined [getKeys] and
+/// [readValue] helpers.
+YamlMappingEntry _lazy(Object? v, GetKeys getKeys, GetValue readValue) sync* {
+  var index = 0;
+
+  for (final key in getKeys(v)) {
+    final e = MapEntry(key, readValue(v, (key: key, index: index)));
+    yield e;
+    ++index;
+  }
+}
+
+/// A [YamlMapping] wrapper that allows you to wrap an object and provide
+/// a custom [GetKeys] callback for extracting keys and a [GetValue] callback
+/// for extracting the value associated with each key.
+///
+/// {@category dumpable_view}
+/// {@category dump_map}
+final class CustomMap extends YamlMapping<Object?> {
+  CustomMap(super.node);
+
+  /// Obtains the keys from a custom [node]. Duplicate keys will not have their
+  /// entries visited by the `TreeBuilder`.
+  GetKeys getKeys = (o) => [o];
+
+  /// Obtains the values from the [node] via its keys.
+  GetValue readValue = (_, _) => null;
+
+  @override
+  MapToYaml get toFormat =>
+      (o) => _lazy(o, getKeys, readValue);
 }

--- a/packages/dump_yaml/test/block_comments_test.dart
+++ b/packages/dump_yaml/test/block_comments_test.dart
@@ -231,7 +231,7 @@ void main() {
                     ..commentStyle = CommentStyle.block
                     ..comments.addAll(_comments),
 
-                  YamlMapping({})
+                  DartMap({})
                     ..commentStyle = CommentStyle.block
                     ..comments.addAll(_comments),
                 ])

--- a/packages/dump_yaml/test/document_test.dart
+++ b/packages/dump_yaml/test/document_test.dart
@@ -55,7 +55,7 @@ void main() {
           VerbatimTag.fromTagShorthand(TagShorthand.primary('hello')),
         ),
 
-        YamlMapping('from')
+        CustomMap('from')
           ..forceInline = true
           ..withNodeTag(TagShorthand.primary('world')),
       ]);

--- a/packages/dump_yaml/test/possessive_comments_test.dart
+++ b/packages/dump_yaml/test/possessive_comments_test.dart
@@ -39,8 +39,8 @@ void main() {
             YamlIterable([])
               ..nodeStyle = NodeStyle.flow
               ..comments.addAll(_comments),
-            YamlMapping({'block': 'map'})..comments.addAll(_comments),
-            YamlMapping({})
+            DartMap({'block': 'map'})..comments.addAll(_comments),
+            DartMap({})
               ..nodeStyle = NodeStyle.flow
               ..comments.addAll(_comments),
           ]),
@@ -84,7 +84,7 @@ void main() {
     final key = ScalarView(24)..comments.addAll(_comments);
     final map = {key: 'value'};
 
-    dumper.dump([map, YamlMapping(map)..nodeStyle = NodeStyle.flow]);
+    dumper.dump([map, DartMap(map)..nodeStyle = NodeStyle.flow]);
 
     check(buffer.toString()).equals('''
 - ? # possessive

--- a/packages/dump_yaml/test/recursive_test.dart
+++ b/packages/dump_yaml/test/recursive_test.dart
@@ -26,7 +26,7 @@ void main() {
 
   test('Detects and creates an alias for self-referential maps', () {
     final map = <String, Object>{'key': 'value'};
-    map['self'] = YamlMapping(map);
+    map['self'] = DartMap(map);
 
     // Block maps
     check(dumpAsYaml(map, config: Config.defaults())).equals('''
@@ -38,13 +38,13 @@ self: *recursive
 
   test("Detects and uses a view's anchor for self-referential objects", () {
     final map = <String, Object>{};
-    map['self'] = YamlMapping(map);
+    map['self'] = DartMap(map);
 
     final list = <Object?>['hello'];
 
     list
       ..add(list)
-      ..add(YamlMapping(map)..anchor = 'map');
+      ..add(DartMap(map)..anchor = 'map');
 
     map['iter'] = list;
 
@@ -93,7 +93,7 @@ self: *recursive
 
   test('ScalarView has no self reference', () {
     final view = ScalarView(24);
-    check((view..node = view).node).equals(24);
-    check((view..node = 0).node).equals(0);
+    check((view..scalar = view).node).equals(24);
+    check((view..scalar = 0).node).equals(0);
   });
 }

--- a/packages/dump_yaml/test/trailing_comments_test.dart
+++ b/packages/dump_yaml/test/trailing_comments_test.dart
@@ -37,7 +37,7 @@ void main() {
             ..commentStyle = CommentStyle.trailing
             ..comments.addAll(_comments),
 
-          YamlMapping({})
+          DartMap({})
             ..nodeStyle = NodeStyle.flow
             ..commentStyle = CommentStyle.trailing
             ..comments.addAll(_comments),
@@ -162,7 +162,7 @@ void main() {
 ''');
 
     buffer.clear();
-    dumper.dump(YamlMapping(map)..nodeStyle = NodeStyle.flow);
+    dumper.dump(DartMap(map)..nodeStyle = NodeStyle.flow);
 
     check(buffer.toString()).equals('''
 {
@@ -194,7 +194,7 @@ void main() {
           ..nodeStyle = NodeStyle.flow
           ..forceInline = true,
 
-        YamlMapping({0: flowNodes})
+        DartMap({0: flowNodes})
           ..comments.addAll(_comments)
           ..commentStyle = CommentStyle.trailing
           ..nodeStyle = NodeStyle.flow

--- a/packages/dump_yaml/test/tree_builder_test.dart
+++ b/packages/dump_yaml/test/tree_builder_test.dart
@@ -88,7 +88,7 @@ void main() {
     });
 
     test('Returns a collection view for a map', () {
-      treeBuilder.buildFor(YamlMapping(['converted to key']));
+      treeBuilder.buildFor(CustomMap(['converted to key']));
 
       check(treeBuilder.builtNode()).isA<CollectionNode<MappingEntry>>()
         ..hasStyle(NodeStyle.block)
@@ -108,14 +108,19 @@ void main() {
 
     test('Removes duplicates from a custom YamlMapping', () {
       treeBuilder.buildFor(
-        YamlMapping([
-          ('sneaky', 'entry'),
-          ('sneaky', 'entry'),
-          MapEntry(['key'], null),
-          ['key'],
-          {'key': 'value'},
-          {'key': 'value'},
-        ]),
+        CustomMap([
+            ('sneaky', 'entry'),
+            ('sneaky', 'entry'),
+            MapEntry(['key'], null),
+            ['key'],
+            {'key': 'value'},
+            {'key': 'value'},
+          ])
+          ..getKeys = ((obj) =>
+              (obj as Iterable).map((e) => e is MapEntry ? e.key : e))
+          ..readValue = (map, current) => current.index == 2
+              ? ((map as List)[2] as MapEntry).value
+              : current.key,
       );
 
       check(
@@ -133,7 +138,7 @@ void main() {
       ).throws();
 
       check(
-        () => treeBuilder.buildFor(YamlMapping([])..withNodeTag(sequenceTag)),
+        () => treeBuilder.buildFor(CustomMap([])..withNodeTag(sequenceTag)),
       ).throws();
     });
   });
@@ -143,7 +148,7 @@ void main() {
       test('Block style allows all styles', () {
         treeBuilder.buildFor([
           'scalar',
-          YamlMapping('key')..nodeStyle = NodeStyle.flow,
+          CustomMap('key')..nodeStyle = NodeStyle.flow,
         ], config: TreeConfig.block());
 
         check(treeBuilder.builtNode()).isA<ListNode>().whoseNode().any(
@@ -228,7 +233,7 @@ void main() {
         treeBuilder.buildFor([
           ScalarView('hello')..withNodeTag(spoof),
           YamlIterable('world')..withNodeTag(spoof),
-          YamlMapping('custom')..withNodeTag(spoof),
+          CustomMap('custom')..withNodeTag(spoof),
         ]);
 
         check(

--- a/packages/dump_yaml/test/tree_builder_test.dart
+++ b/packages/dump_yaml/test/tree_builder_test.dart
@@ -310,6 +310,17 @@ void main() {
           );
     });
 
+    test('Includes (invalid) anchors', () {
+      const ref = 'invalid-yaml';
+
+      check(
+        (treeBuilder
+              ..includeAnchors([ref])
+              ..buildFor(Alias(ref)))
+            .builtNode(),
+      ).isA<ReferenceNode>().whoseNode().equals('*$ref');
+    });
+
     test('Throws if no such anchor is present', () {
       check(() => treeBuilder.buildFor(Alias('24'))).throws();
       check(


### PR DESCRIPTION
This PR:

- Makes `YamlMapping` flexible. Reworks restrictions introduced in 31755d601b164ce238453f8e765e89824c0c4033 via #135.
- Adds minor QoL improvements to `TreeBuilder`