### PR TITLE
fix(parser): prevent flow delimiters from affecting block plain scalars

### DIFF
--- a/packages/rookie_yaml/lib/src/parser/document/scalars/flow/plain.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/scalars/flow/plain.dart
@@ -204,7 +204,7 @@ ParsedScalarInfo? plainParser(
           foundLineBreak = foundLineBreak || hasLineBreak;
         }
 
-      case _ when (isImplicit || isInFlowContext) && char.isFlowDelimiter():
+      case _ when isInFlowContext && char.isFlowDelimiter():
         break chunker;
 
       default:


### PR DESCRIPTION
The parser can now parse the full [YAML Spec](https://github.com/yaml/yaml-grammar/blob/master/yaml-spec-1.2.yaml)'s `yaml` format. 😄 