### PR TITLE
refactor(parser): loader tweaks

### DIFF
--- a/packages/rookie_yaml/lib/rookie_yaml.dart
+++ b/packages/rookie_yaml/lib/rookie_yaml.dart
@@ -1,5 +1,7 @@
 library;
 
+export 'package:logging/logging.dart' show hierarchicalLoggingEnabled;
+
 export 'src/loaders/loader.dart';
 export 'src/parser/custom_resolvers.dart';
 export 'src/parser/delegates/object_delegate.dart'

--- a/packages/rookie_yaml/lib/src/loaders/loader.dart
+++ b/packages/rookie_yaml/lib/src/loaders/loader.dart
@@ -17,7 +17,7 @@ part 'dart_objects.dart';
 extension type YamlSource._(Iterator<Unicode> source)
     implements Iterator<Unicode> {
   /// Creates a simple input from a [yaml] string.
-  YamlSource.simpleString(String yaml) : this._(unicodeFromString(yaml));
+  YamlSource.simpleString(String yaml) : this._(SpannedIterator.ofString(yaml));
 
   /// Creates an input from a [yaml] source string that does not allow unpaired
   /// surrogate code units.

--- a/packages/rookie_yaml/lib/src/scanner/encoding/utf_utils.dart
+++ b/packages/rookie_yaml/lib/src/scanner/encoding/utf_utils.dart
@@ -281,6 +281,15 @@ final class SpannedIterator<Iter extends Iterator<int>>
   /// Underlying iterator with code units.
   final Iter iterator;
 
+  /// Creates a [SpannedIterator] using the [yaml] string's [RuneIterator].
+  factory SpannedIterator.ofString(String yaml) {
+    return SpannedIterator.iterator(
+          yaml.runes.iterator,
+          spanned: (iterator) => iterator.currentSize,
+        )
+        as SpannedIterator<Iter>;
+  }
+
   /// Current code unit with its span information.
   Unicode? _current;
 
@@ -298,10 +307,3 @@ final class SpannedIterator<Iter extends Iterator<int>>
     return true;
   }
 }
-
-/// Creates a [SpannedIterator] using the [string]'s [RuneIterator].
-SpannedIterator<RuneIterator> unicodeFromString(String string) =>
-    SpannedIterator.iterator(
-      string.runes.iterator,
-      spanned: (iterator) => iterator.currentSize,
-    );

--- a/packages/rookie_yaml/lib/src/scanner/source_iterator.dart
+++ b/packages/rookie_yaml/lib/src/scanner/source_iterator.dart
@@ -176,7 +176,8 @@ final class UnicodeIterator extends SourceIterator {
 
   /// Creates a [UnicodeIterator] that uses the underlying code units to iterate
   /// the string [source].
-  UnicodeIterator.ofString(String source) : this._(unicodeFromString(source));
+  UnicodeIterator.ofString(String source)
+    : this._(SpannedIterator.ofString(source));
 
   /// Creates a [UnicodeIterator] that iterates a sequence of utf bytes.
   UnicodeIterator.ofUnicode(Iterator<Unicode> source) : this._(source);


### PR DESCRIPTION
- Make the `unicodeFromString` a factory constructor within `SpannedIterator`.
- Export the `hierarchicalLoggingEnabled` variable used by the package from `package:logging`.