### PR TITLE
fix(parser): always degenerate to custom types when a tag is captured

### DIFF
--- a/packages/rookie_yaml/lib/src/parser/document/block_nodes/special_block_entry.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/block_nodes/special_block_entry.dart
@@ -1,4 +1,3 @@
-import 'package:rookie_yaml/src/parser/custom_resolvers.dart';
 import 'package:rookie_yaml/src/parser/delegates/object_delegate.dart';
 import 'package:rookie_yaml/src/parser/document/block_nodes/block_sequence.dart';
 import 'package:rookie_yaml/src/parser/document/block_nodes/block_wildcard.dart';
@@ -19,40 +18,17 @@ typedef SpecialBlockSequenceInfo = ({
   BlockInfo blockInfo,
 });
 
-/// Creates a [SequenceLikeDelegate] based on its kind.
-///
-/// An [IterableToObjectDelegate] may be returned if the parser was instructed
-/// to treat a specific tag embedded in the node's [property] as a [CustomKind].
-/// Otherwise, a generic [SequenceDelegate] is returned.
-SequenceLikeDelegate<Obj, Obj> _delegateHelper<Obj>(
-  ParsedProperty? property, {
-  required RuneOffset start,
-  required int indent,
-  required int indentLevel,
-  required ParserState<Obj> state,
-}) {
-  // Check if this special sequence was annotated with custom properties
-  if (property case NodeProperty(
-    kind: CustomKind.iterable,
-    customResolver: ObjectFromIterable<Obj, Obj> resolver,
-  )) {
-    return SequenceLikeDelegate.boxed(
-      resolver.onCustomIterable(),
-      collectionStyle: NodeStyle.block,
-      indentLevel: indentLevel,
-      indent: indent,
-      start: start,
-      afterSequence: resolver.afterObject<Obj>(),
-    );
-  }
+typedef _CheckedSpecial<Obj> = (
+  SequenceLikeDelegate<Obj, Obj>? node,
+  ParsedProperty? propery,
+);
 
-  return state.defaultSequenceDelegate(
-    style: NodeStyle.block,
-    indent: indent,
-    indentLevel: indentLevel,
-    start: start,
-    kind: property?.kind ?? YamlCollectionKind.sequence,
-  );
+_CheckedSpecial<Obj>? _checkIfSpecial<Obj>(NodeDelegate<Obj> node) {
+  return switch (node) {
+    EfficientScalarDelegate(isNullDelegate: true) => (null, node.property),
+    SequenceLikeDelegate<Obj, Obj>() => (node, null),
+    _ => null,
+  };
 }
 
 /// Attempts to parse a block sequence on the same indent level as its implicit
@@ -95,7 +71,7 @@ SpecialBlockSequenceInfo composeSpecialBlockSequence<Obj>(
 }) {
   final (:blockInfo, :node) = blockNode;
 
-  if (node case EfficientScalarDelegate(isNullDelegate: true)
+  if (_checkIfSpecial<Obj>(node) case final checked?
       when !state.iterator.isEOF &&
           !blockInfo.docMarker.stopIfParsingDoc &&
           blockInfo.exitIndent == keyIndent &&
@@ -105,7 +81,10 @@ SpecialBlockSequenceInfo composeSpecialBlockSequence<Obj>(
       state,
       keyIndent: keyIndent,
       keyIndentLevel: keyIndentLevel,
-      property: node.property,
+      delegate: checked.$1
+        ?..indent = keyIndent
+        ..indentLevel = keyIndentLevel,
+      property: checked.$2,
       onSequence: onSequenceOrBlockNode,
       onNextImplicitEntry: onNextImplicitEntry,
     );
@@ -149,21 +128,21 @@ SpecialBlockSequenceInfo parseSpecialBlockSequence<Obj>(
   ParserState<Obj> state, {
   required int keyIndent,
   required int keyIndentLevel,
-  required ParsedProperty? property,
   required void Function(NodeDelegate<Obj> sequence) onSequence,
   required OnBlockMapEntry<Obj> onNextImplicitEntry,
   RuneOffset? structuralStart,
+  SequenceLikeDelegate<Obj, Obj>? delegate,
+  ParsedProperty? property,
 }) {
-  final ParserState(:iterator) = state;
-
   final (:greedyOnPlain, :sequence) = parseBlockSequence(
-    _delegateHelper<Obj>(
-      property,
-      state: state,
-      start: structuralStart ?? iterator.currentLineInfo.current,
-      indent: keyIndent,
-      indentLevel: keyIndentLevel,
-    )..updateNodeProperties = property,
+    delegate ??
+        state.defaultSequenceDelegate(
+          style: NodeStyle.block,
+          indent: keyIndent,
+          indentLevel: keyIndentLevel,
+          start: state.iterator.currentLineInfo.current,
+          kind: property?.kind ?? YamlCollectionKind.sequence,
+        ),
     state: state,
     levelWithBlockMap: true,
   );

--- a/packages/rookie_yaml/lib/src/parser/document/nodes_by_kind/custom_node.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/nodes_by_kind/custom_node.dart
@@ -17,6 +17,7 @@ import 'package:rookie_yaml/src/parser/document/scalars/flow/single_quoted.dart'
 import 'package:rookie_yaml/src/parser/document/state/parser_state.dart';
 import 'package:rookie_yaml/src/parser/parser_utils.dart';
 import 'package:rookie_yaml/src/scanner/source_iterator.dart';
+import 'package:rookie_yaml/src/scanner/span.dart';
 
 import 'package:rookie_yaml/src/schema/yaml_comment.dart';
 import 'package:rookie_yaml/src/schema/yaml_node.dart';
@@ -48,6 +49,45 @@ T _parseCustomKind<T, Obj>(
     ),
     _ => onMatchScalar(resolver as ObjectFromScalarBytes<Obj>),
   };
+}
+
+/// Creates an empty block node of the specified [kind] since the empty scalar
+/// was captured by a tag present in the [property].
+NodeDelegate<Obj> emptyBlockOfKind<Obj>(
+  CustomKind kind,
+  NodeProperty property, {
+  required int indentLevel,
+  required int indent,
+  required RuneOffset start,
+}) {
+  return _parseCustomKind<NodeDelegate<Obj>, Obj>(
+    kind,
+    property: property,
+    onMatchMap: (mapBuilder) => MapLikeDelegate.boxed(
+      mapBuilder.onCustomMap(),
+      collectionStyle: NodeStyle.block,
+      indentLevel: indentLevel,
+      indent: indent,
+      start: start,
+      afterMapping: mapBuilder.afterObject<Obj>(),
+    ),
+    onMatchIterable: (listBuilder) => SequenceLikeDelegate.boxed(
+      listBuilder.onCustomIterable(),
+      collectionStyle: NodeStyle.block,
+      indentLevel: indentLevel,
+      indent: indent,
+      start: start,
+      afterSequence: listBuilder.afterObject<Obj>(),
+    ),
+    onMatchScalar: (resolver) => BoxedScalar(
+      resolver.onCustomScalar(),
+      scalarStyle: ScalarStyle.plain,
+      indentLevel: indentLevel,
+      indent: indent,
+      start: start,
+      afterScalar: resolver.afterObject<Obj>(),
+    ),
+  );
 }
 
 typedef OnScalar<R, T> =

--- a/packages/rookie_yaml/lib/src/parser/document/scalars/scalars.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/scalars/scalars.dart
@@ -42,6 +42,13 @@ NodeDelegate<Obj> emptyBlockNode<Obj>(
       indentLevel: indentLevel,
       indent: indent,
     ),
+    NodeProperty(kind: final CustomKind kind) => emptyBlockOfKind<Obj>(
+      kind,
+      property,
+      indentLevel: indentLevel,
+      indent: indent,
+      start: start,
+    ),
     _ => nullScalarDelegate(
       indentLevel: indentLevel,
       indent: indent,

--- a/packages/rookie_yaml/test/node_resolver_test.dart
+++ b/packages/rookie_yaml/test/node_resolver_test.dart
@@ -101,6 +101,32 @@ block: value
   });
 
   group('Resolvers', () {
+    test('Handles captured empty resolver tags correctly', () {
+      final yaml =
+          '''
+- $setTag
+- $mappingTag
+- $integerTag
+''';
+
+      check(
+        loadResolvedDartObject(
+          yaml,
+          nodeResolvers: {
+            setTag: listResolver,
+            mappingTag: mapResolver,
+            integerTag: ObjectFromScalarBytes(
+              onCustomScalar: () => BytesToScalar.sliced(mapper: (_) => 24),
+            ),
+          },
+        ),
+      ).isA<List>().containsMatchingInOrder([
+        (seq) => seq.isA<List<int>>().isEmpty(),
+        (map) => map.isA<Set<String>>().isEmpty(),
+        (scalar) => scalar.isA<int>().equals(24),
+      ]);
+    });
+
     test('Loads a predictable strongly typed set from a map', () {
       // Flow map that has no values
       final sources = [


### PR DESCRIPTION
This ensures that the parser always defaults to the custom type even when the tag is present but the scalar is empty.

- Prevents empty scalars from bypassing custom types without a check.
- Add test.