### PR TITLE
Parser improvements

### DIFF
--- a/packages/rookie_yaml/lib/src/parser/document/node_utils.dart
+++ b/packages/rookie_yaml/lib/src/parser/document/node_utils.dart
@@ -184,6 +184,7 @@ T initFlowCollection<R, T extends NodeDelegate<R>>(
   }
 
   iterator.nextChar();
+  final flowCollection = init(current);
 
   if (!nextSafeLineInFlow(
     iterator,
@@ -201,7 +202,7 @@ T initFlowCollection<R, T extends NodeDelegate<R>>(
     );
   }
 
-  return init(current);
+  return flowCollection;
 }
 
 /// Checks if the current char in the [iterator] matches the closing [delimiter]

--- a/packages/rookie_yaml/lib/src/scanner/source_iterator.dart
+++ b/packages/rookie_yaml/lib/src/scanner/source_iterator.dart
@@ -36,8 +36,8 @@ RuneOffset _getLineStart({
 }) => (
   lineIndex: lineIndex,
   columnIndex: 0,
-  span: 0,
-  rawOffset: rawOffset + span,
+  span: span,
+  rawOffset: rawOffset,
   offset: currentOffset,
 );
 
@@ -153,7 +153,10 @@ final class UnicodeIterator extends SourceIterator {
       _currentCharSpan = char.span;
       _currentChar = char.unicode;
 
-      _lineStartOffset = _getLineStart(span: _currentCharSpan);
+      _lineStartOffset = _getLineStart(
+        span: _currentCharSpan,
+        rawOffset: _currentCharSpan - 1,
+      );
 
       if (!_iterator.moveNext()) {
         _bufferCurrent();


### PR DESCRIPTION
- Calls `init` on a flow collection before performing any action on an internal node's content.
- Fixes an issue where the raw offset for every line except the first line were incremented.