### PR TITLE
Equality improvements

### DIFF
--- a/packages/dump_yaml/lib/src/event_tree/hashing.dart
+++ b/packages/dump_yaml/lib/src/event_tree/hashing.dart
@@ -1,0 +1,81 @@
+import 'package:collection/collection.dart';
+import 'package:crypto/crypto.dart';
+
+/// A SHA-256 hash that uniquely identifies a type.
+sealed class FreeHash {
+  /// SHA-256 hex.
+  String get hexHash;
+
+  static String _combinedHashOnDemand(List<List<int>> toHash) =>
+      sha256.convert(CombinedListView(toHash)).toString();
+
+  @override
+  int get hashCode => hexHash.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is FreeHash && hexHash == other.hexHash;
+}
+
+/// A SHA-256 hash that is available on demand.
+final class QualifiedHash extends FreeHash {
+  QualifiedHash._(this.hexHash);
+
+  QualifiedHash.scalar(String seedTag, String content)
+    : this._(
+        FreeHash._combinedHashOnDemand([
+          'SCALAR'.codeUnits,
+          seedTag.codeUnits,
+          content.codeUnits,
+        ]),
+      );
+
+  QualifiedHash.danglingReference(String anchor)
+    : this._(
+        FreeHash._combinedHashOnDemand(['ALIAS'.codeUnits, anchor.codeUnits]),
+      );
+
+  @override
+  final String hexHash;
+}
+
+const _emptyMap = ('MAPPING', {});
+
+const _emptyList = ('SEQUENCE', []);
+
+/// A SHA-256 hash computed on demand for every entry of a collection.
+final class LazyHash extends FreeHash {
+  LazyHash({required bool isMap, required String seedTag}) {
+    hexHash = _initSeed(seedTag, isMap ? _emptyMap : _emptyList);
+  }
+
+  /// Uniquely identifies a type bound to this
+  late final String id;
+
+  @override
+  late String hexHash;
+
+  /// Initializes a collection's SHA-256 hash.
+  String _initSeed(String seedTag, (String, Object) seed) {
+    final (type, collection) = seed;
+    id = type;
+
+    // YAML-TYPE, TAG-TYPE, EMPTY-STATE-AS-SEED
+    return FreeHash._combinedHashOnDemand([
+      type.codeUnits,
+      seedTag.codeUnits,
+      identityHashCode(collection).toRadixString(16).codeUnits,
+    ]);
+  }
+
+  /// Hashes the [keyOrElementHash] (and [valueHashIfMap] if present) with
+  /// the existing hash as the seed.
+  void incrementalOnDemand(String keyOrElementHash, [String? valueHashIfMap]) {
+    hexHash = FreeHash._combinedHashOnDemand([
+      hexHash.codeUnits,
+      id.codeUnits,
+      keyOrElementHash.codeUnits,
+      ?valueHashIfMap?.codeUnits,
+    ]);
+  }
+}

--- a/packages/dump_yaml/lib/src/event_tree/node.dart
+++ b/packages/dump_yaml/lib/src/event_tree/node.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 
+import 'package:dump_yaml/src/event_tree/hashing.dart';
 import 'package:dump_yaml/src/views/dumpable.dart';
 import 'package:meta/meta.dart';
 import 'package:rookie_yaml/rookie_yaml.dart';
@@ -24,6 +25,7 @@ extension Doc on DocumentNode {
 abstract class TreeNode<T> extends CompactYamlNode {
   TreeNode(
     this.nodeStyle, {
+    required this.nodeHash,
     Iterable<String>? comments,
     CommentStyle? commentStyle,
     this.anchor,
@@ -36,6 +38,8 @@ abstract class TreeNode<T> extends CompactYamlNode {
 
   /// Node's comment style
   final CommentStyle commentStyle;
+
+  final FreeHash nodeHash;
 
   @override
   final NodeStyle nodeStyle;
@@ -69,6 +73,7 @@ final class ReferenceNode extends TreeNode<String> {
   ReferenceNode(
     this.alias, {
     required super.comments,
+    required super.nodeHash,
     super.commentStyle,
     this.recursive = false,
   }) : super(NodeStyle.flow);
@@ -98,6 +103,7 @@ final class ContentNode extends TreeNode<Iterable<String>> {
   ContentNode(
     this.node,
     super.nodeStyle, {
+    required super.nodeHash,
     required this.inheritParentIndent,
     required this.isMultiline,
     super.comments,
@@ -129,6 +135,7 @@ final class CollectionNode<T> extends TreeNode<ListQueue<T>> {
   CollectionNode(
     this.node,
     super.nodeStyle, {
+    required super.nodeHash,
     required this.nodeType,
     required this.forcedInline,
     required this.isMultiline,

--- a/packages/dump_yaml/lib/src/event_tree/scalar_content.dart
+++ b/packages/dump_yaml/lib/src/event_tree/scalar_content.dart
@@ -116,7 +116,7 @@ Iterable<String> _toYamlScalar(
           unfolding: unfoldNormal,
         );
 
-        yield* isDoubleQuoted || lines.isEmpty ? asQuoted(lines) : lines;
+        yield* isDoubleQuoted ? asQuoted(lines) : lines;
       }
 
     // Block Styles

--- a/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
+++ b/packages/dump_yaml/lib/src/event_tree/tree_builder.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:dump_yaml/src/configs.dart';
+import 'package:dump_yaml/src/event_tree/hashing.dart';
 import 'package:dump_yaml/src/event_tree/node.dart';
 import 'package:dump_yaml/src/event_tree/scalar_content.dart';
 import 'package:dump_yaml/src/event_tree/visitor.dart';
@@ -13,28 +14,35 @@ extension on String {
       isEmpty ? this : '${this[0].toUpperCase()}${substring(1)}';
 }
 
-bool _genericEquals(Object? thiz, Object? that) {
-  if ((thiz is Map && that is Map) || (thiz is List && that is List)) {
-    return yamlCollectionEquality.equals(thiz, that);
-  }
+final _missing = TagShorthand.primary('unresolved');
 
-  return thiz == that;
-}
+/// Callback for tracking the current path.
+typedef PathLogger = void Function(String path);
 
-Object? _unwrapCollections(Object? object) => switch (object) {
-  YamlMapping() || YamlIterable() => (object as ConcreteNode).node,
-  _ => object,
-};
+/// Callback for lazily mapping an object to another.
+typedef ExpandObject = Object? Function(Object? object);
+
+typedef _TagInfo = ({String? qualifiedTag, String generic});
+
+typedef _IfNotRecursive<T> =
+    void Function(
+      String recursiveAnchor,
+      String? qualifiedTag,
+      LazyHash hash,
+      T object,
+    );
+
+void _noOp(String _) {}
 
 mixin _Decomposer {
   /// Anchors in the document.
-  final _anchors = <String>{};
+  final _anchors = <String, FreeHash?>{};
 
   /// Global tags.
   final _globalTags = <TagHandle, GlobalTag>{};
 
-  String? _pushAnchor(String? anchor) {
-    if (anchor != null) _anchors.add(anchor);
+  String? _pushAnchor(String? anchor, FreeHash hash) {
+    if (anchor != null) _anchors[anchor] = hash;
     return anchor;
   }
 
@@ -46,9 +54,8 @@ mixin _Decomposer {
   String? _localTag(
     ResolvedTag? nodeTag, {
     required void Function(TagShorthand tag) validate,
-    bool includeGeneric = false,
   }) {
-    if (nodeTag == null || (!includeGeneric && nodeTag.isGeneric)) return null;
+    if (nodeTag == null) return null;
     final (:verbatim, :globalTag, :tag) = resolvedTagInfo(nodeTag);
 
     // Cannot have verbatim and global/local tag.
@@ -102,34 +109,33 @@ A global tag with the current tag handle already exists.
     return tag.toString();
   }
 
+  TagShorthand _genericTag(Object? object) => switch (object) {
+    Iterable() => /* object is Set ? setTag : */ sequenceTag,
+    Map() => mappingTag,
+    int() => integerTag,
+    double() => floatTag,
+    String() => stringTag,
+    bool() => booleanTag,
+    null => nullTag,
+    _ => _missing,
+  };
+
   /// Matches the [object] to its YAML Schema tag only if [includeGeneric] is
   /// `true`.
-  String? _genericIfMissing(Object? object, {bool includeGeneric = false}) {
-    if (!includeGeneric) return null;
-
-    return switch (object) {
-      Iterable() => /* object is Set ? setTag : */ sequenceTag,
-      Map() => mappingTag,
-      int() => integerTag,
-      double() => floatTag,
-      String() => stringTag,
-      bool() => booleanTag,
-      null => nullTag,
-      _ => null,
-    }?.toString();
+  _TagInfo _genericIfMissing({
+    Object? object,
+    bool includeGeneric = false,
+    TagShorthand? qualified,
+    TagShorthand? generic,
+  }) {
+    final genericTag = qualified ?? generic ?? _genericTag(object);
+    return (
+      qualifiedTag: (qualified ?? (includeGeneric ? genericTag : null))
+          ?.toString(),
+      generic: genericTag.toString(),
+    );
   }
-
-  String? _kindToTag(NodeConfig config, TagShorthand tag) =>
-      config.includeSchemaTag ? tag.toString() : null;
 }
-
-/// Callback for tracking the current path.
-typedef PathLogger = void Function(String path);
-
-/// Callback for lazily mapping an object to another.
-typedef ExpandObject = Object? Function(Object? object);
-
-void _noOp(String _) {}
 
 /// Maps object to itself.
 Object? _identity(Object? object) => object;
@@ -190,10 +196,10 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   int? _recursiveCount;
 
   /// Tracks the current collection-like object being walked.
-  final _recursiveTracker = HashMap<Object?, String>.identity();
+  final _recursiveTracker = HashMap<Object?, (String, FreeHash)>.identity();
 
   /// Links an [object] to an [anchor] just before the builder walks.
-  String _trackRecursive(Object? object, [String? anchor]) {
+  String _trackRecursive(Object? object, FreeHash hash, String? anchor) {
     String fetchCount() {
       var out = '';
 
@@ -208,7 +214,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     }
 
     final tracker = anchor ?? 'recursive${fetchCount()}';
-    _recursiveTracker[object] = tracker;
+    _recursiveTracker[object] = (tracker, hash);
     return tracker;
   }
 
@@ -254,24 +260,30 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   bool _buildWithStyle(NodeStyle style, [NodeStyle? parent]) =>
       !((parent ?? _nearestCollection()).isIncompatible(style));
 
+  _TagInfo _tagFromView(
+    ResolvedTag? tag, {
+    required TagShorthand generic,
+    required void Function(TagShorthand tag) validate,
+  }) {
+    final qualified = _localTag(tag, validate: validate);
+    return (qualifiedTag: qualified, generic: qualified ?? generic.toString());
+  }
+
   /// Visits a recursive [object] and tracks the object's state.
   void _visitRecursiveCandidate<T>(
     T object, {
-    required void Function(String? recursiveAnchor, T object) visit,
-    required bool trackObject,
+    required _IfNotRecursive<T> visit,
+    required bool isMap,
+    required _TagInfo tagInfo,
     String? anchorOnVisit,
     Iterable<String>? comments,
     CommentStyle? commentStyle,
   }) {
-    if (!trackObject) {
-      visit(null, object);
-      return;
-    }
-
-    if (_recursiveTracker[object] case String anchored) {
+    if (_recursiveTracker[object] case (String anchored, FreeHash refHash)) {
       _addNode(
         ReferenceNode(
           anchored,
+          nodeHash: refHash,
           comments: comments,
           commentStyle: commentStyle,
           recursive: true,
@@ -282,8 +294,9 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
       return;
     }
 
-    final anchor = _trackRecursive(object, anchorOnVisit);
-    visit(anchor, object);
+    final hash = LazyHash(isMap: isMap, seedTag: tagInfo.generic);
+    final anchor = _trackRecursive(object, hash, anchorOnVisit);
+    visit(anchor, tagInfo.qualifiedTag, hash, object);
     _recursiveTracker.remove(object);
   }
 
@@ -298,10 +311,19 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   void visitAlias(Alias alias) {
     final ref = alias.alias;
 
-    if (_anchors.contains(ref)) {
+    if (_anchors.containsKey(ref)) {
+      var hash = _anchors[ref];
+
+      // Assume that these anchors injected into the builder.
+      if (hash == null) {
+        hash = QualifiedHash.danglingReference(ref);
+        _anchors[ref] = hash;
+      }
+
       _addNode(
         ReferenceNode(
           ref,
+          nodeHash: hash,
           comments: alias.comments,
           commentStyle: alias.commentStyle,
         ),
@@ -317,11 +339,16 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   @override
   void visitIterable(Iterable<Object?> iterable) => _visitRecursiveCandidate(
     iterable,
-    trackObject: true,
-    visit: (anchor, object) => _buildIterable(
+    isMap: false,
+    tagInfo: _genericIfMissing(
+      includeGeneric: _config.includeSchemaTag,
+      generic: sequenceTag,
+    ),
+    visit: (anchor, tag, hash, object) => _buildIterable(
       object,
       style: _config.iterableStyle,
-      localTag: _kindToTag(_config, sequenceTag),
+      hash: hash,
+      localTag: tag,
       forceInline: _inlineRules.last,
       recursiveAnchor: anchor,
     ),
@@ -333,23 +360,25 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
 
     _visitRecursiveCandidate(
       iterable.node,
-      trackObject: node is Iterable,
-      anchorOnVisit: _pushAnchor(anchor),
+      isMap: false,
+      tagInfo: _tagFromView(
+        iterable.tag,
+        generic: sequenceTag,
+        validate: throwIfNotListTag,
+      ),
       comments: comments,
       commentStyle: commentStyle,
-      visit: (recursive, object) => _buildIterable(
+      anchorOnVisit: anchor,
+      visit: (recursive, tag, hash, object) => _buildIterable(
         iterable.toFormat(object),
         style: iterable.nodeStyle,
+        hash: hash,
         forceInline: iterable.forceInline || _inlineRules.last,
         comments: comments,
         anchor: anchor,
         recursiveAnchor: recursive,
         commentStyle: commentStyle,
-        localTag: _localTag(
-          iterable.tag,
-          validate: throwIfNotListTag,
-          includeGeneric: _config.includeSchemaTag,
-        ),
+        localTag: tag,
       ),
     );
   }
@@ -357,11 +386,16 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   @override
   void visitMap(Map<Object?, Object?> map) => _visitRecursiveCandidate(
     map,
-    trackObject: true,
-    visit: (anchor, object) => _buildMap(
+    isMap: true,
+    tagInfo: _genericIfMissing(
+      includeGeneric: _config.includeSchemaTag,
+      generic: mappingTag,
+    ),
+    visit: (anchor, tag, hash, object) => _buildMap(
       object.entries,
       style: _config.mapStyle,
-      localTag: _kindToTag(_config, mappingTag),
+      hash: hash,
+      localTag: tag,
       forceInline: _inlineRules.last,
       recursiveAnchor: anchor,
     ),
@@ -373,57 +407,56 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
 
     _visitRecursiveCandidate(
       mapping.node,
-      trackObject: node is Map,
-      anchorOnVisit: _pushAnchor(anchor),
+      isMap: true,
+      tagInfo: _tagFromView(
+        mapping.tag,
+        validate: throwIfNotMapTag,
+        generic: mappingTag,
+      ),
+      anchorOnVisit: anchor,
       comments: comments,
       commentStyle: commentStyle,
-      visit: (recursive, object) => _buildMap(
+      visit: (recursive, tag, hash, object) => _buildMap(
         mapping.toFormat(object),
         style: mapping.nodeStyle,
+        hash: hash,
         forceInline: mapping.forceInline || _inlineRules.last,
         comments: comments,
         anchor: anchor,
         recursiveAnchor: recursive,
         commentStyle: commentStyle,
-        localTag: _localTag(
-          mapping.tag,
-          validate: throwIfNotMapTag,
-          includeGeneric: _config.includeSchemaTag,
-        ),
+        localTag: tag,
       ),
     );
   }
 
   @override
-  void visitScalar(Object? scalar) {
-    _buildScalar(
-      scalar?.toString() ?? '',
-      scalarStyle: _config.scalarStyle,
-      localTag: _genericIfMissing(
-        scalar,
-        includeGeneric: _config.includeSchemaTag,
-      ),
-      forceInline: _inlineRules.last,
-    );
-  }
+  void visitScalar(Object? scalar) => _buildScalar(
+    scalar?.toString() ?? '',
+    scalarStyle: _config.scalarStyle,
+    tagInfo: _genericIfMissing(
+      object: scalar,
+      includeGeneric: _config.includeSchemaTag,
+    ),
+    forceInline: _inlineRules.last,
+  );
 
   @override
   void visitScalarView(ScalarView scalar) {
-    final ScalarView(:comments, :anchor, :tag, :forceInline, :scalarStyle) =
-        scalar;
+    final ScalarView(:node) = scalar;
 
     _buildScalar(
-      scalar.toFormat(scalar.node),
-      scalarStyle: scalarStyle,
+      scalar.toFormat(node),
+      scalarStyle: scalar.scalarStyle,
       emptyAsNull: scalar.emptyAsNull,
-      forceInline: forceInline || _inlineRules.last,
-      comments: comments,
-      anchor: _pushAnchor(anchor),
+      forceInline: scalar.forceInline || _inlineRules.last,
+      comments: scalar.comments,
+      anchor: scalar.anchor,
       commentStyle: scalar.commentStyle,
-      localTag: _localTag(
-        tag,
+      tagInfo: _tagFromView(
+        scalar.tag,
         validate: throwIfNotScalarTag,
-        includeGeneric: _config.includeSchemaTag,
+        generic: _genericTag(node),
       ),
     );
   }
@@ -433,10 +466,10 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     String scalar, {
     required ScalarStyle scalarStyle,
     required bool forceInline,
+    required _TagInfo tagInfo,
     bool emptyAsNull = false,
     List<String>? comments,
     String? anchor,
-    String? localTag,
     CommentStyle? commentStyle,
   }) {
     final collectionStyle = _nearestCollection();
@@ -454,15 +487,18 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
       parentIsBlock: collectionStyle.isBlock,
     );
 
+    final hash = QualifiedHash.scalar(tagInfo.generic, scalar);
+
     _addNode(
       ContentNode(
         lines,
         dumpingStyle.nodeStyle,
+        nodeHash: hash,
         inheritParentIndent: useParentIndent,
         isMultiline: isMultiline,
         comments: comments,
-        anchor: anchor,
-        localTag: localTag,
+        anchor: _pushAnchor(anchor, hash),
+        localTag: tagInfo.qualifiedTag,
         commentStyle: commentStyle?.ofQualified(dumpingStyle.nodeStyle),
       ),
     );
@@ -475,7 +511,8 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     YamlIterableEntry iterable, {
     required NodeStyle style,
     required bool forceInline,
-    required String? recursiveAnchor,
+    required String recursiveAnchor,
+    required LazyHash hash,
     List<String>? comments,
     String? anchor,
     String? localTag,
@@ -484,15 +521,17 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     iterable,
     style: style,
     nodeType: NodeType.list,
+    hash: hash,
     iterate: (index, element) {
       _pushPath(index.toString());
       visitObject(element);
       return true;
     },
-    compose: () {
+    compose: (hash) {
       // One in, one out
       final element = _nodes.removeLast();
       _popPaths(2);
+      hash.incrementalOnDemand(element.nodeHash.hexHash);
       return (element.isMultiline, element);
     },
     forceInline: forceInline,
@@ -508,40 +547,70 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
   void _buildMap(
     YamlMappingEntry iterable, {
     required NodeStyle style,
-    required String? recursiveAnchor,
+    required String recursiveAnchor,
+    required LazyHash hash,
     bool forceInline = false,
     List<String>? comments,
     String? anchor,
     String? localTag,
     CommentStyle? commentStyle,
   }) {
-    final keysSeen = HashSet<Object?>(
-      equals: _genericEquals,
-      hashCode: yamlCollectionEquality.hash,
-    );
+    final keysSeen = HashMap<NodeType, Iterable<FreeHash>>();
 
     // DartMap is just a helpful wrapper for a map.
-    bool pushKey(Object? key) => keysSeen.add(_unwrapCollections(key));
+    bool pushKey(TreeNode<Object> node) {
+      final TreeNode(:nodeType, :nodeHash) = node;
+
+      switch (keysSeen[nodeType]) {
+        case Set<FreeHash> set:
+          return set.add(nodeHash);
+
+        case ListQueue<FreeHash> queue:
+          {
+            final set = queue.toSet();
+            final seen = set.add(nodeHash);
+
+            // Some collection nodes were finalized.
+            if (set.length != queue.length) {
+              keysSeen[nodeType] = ListQueue.of(set);
+            }
+
+            return seen;
+          }
+
+        default:
+          {
+            keysSeen[nodeType] = nodeType == NodeType.alias
+                ? (ListQueue()..add(nodeHash))
+                : {nodeHash};
+
+            return true;
+          }
+      }
+    }
 
     _buildCollection(
       iterable,
       style: style,
       nodeType: NodeType.map,
+      hash: hash,
       iterate: (_, element) {
-        final key = element.key;
+        visitObject(element.key);
 
-        if (!pushKey(key)) {
+        // Quickly determine if this is a duplicate.
+        if (!pushKey(_nodes.last)) {
+          _nodes.removeLast();
           return false;
         }
 
-        visitObject(key);
         visitObject(element.value);
         return true;
       },
-      compose: () {
+      compose: (hash) {
         // Two in, two out
         final value = _nodes.removeLast();
         final key = _nodes.removeLast();
+        hash.incrementalOnDemand(key.nodeHash.hexHash, value.nodeHash.hexHash);
         _popPaths(2);
         return (key.isMultiline || value.isMultiline, (key, value));
       },
@@ -561,12 +630,13 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
     Iterable<E> iterable, {
     required NodeStyle style,
     required NodeType nodeType,
+    required LazyHash hash,
     required bool Function(int index, E element) iterate,
-    required (bool isMultiline, T value) Function() compose,
+    required (bool isMultiline, T value) Function(LazyHash hash) compose,
     required bool forceInline,
     required List<String>? comments,
     required String? anchor,
-    required String? recursiveAnchor,
+    required String recursiveAnchor,
     required String? localTag,
     required CommentStyle? commentStyle,
     required NodeType type,
@@ -594,7 +664,7 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
 
     for (final (index, element) in iterable.indexed) {
       if (!iterate(index, element)) continue;
-      final (isMultiline, node) = compose();
+      final (isMultiline, node) = compose(hash);
       update(isMultiline, node);
       queue.addLast(node);
     }
@@ -603,10 +673,14 @@ final class TreeBuilder with _Decomposer, DartTypeVisitor, ViewVisitor {
       CollectionNode(
         queue,
         buildStyle,
+        nodeHash: hash,
         nodeType: nodeType,
         forcedInline: forceInline,
         isMultiline: spanMultipleLines && queue.isNotEmpty,
-        anchor: anchor ?? (hasRecursiveRef ? recursiveAnchor : null),
+        anchor: _pushAnchor(
+          anchor ?? (hasRecursiveRef ? recursiveAnchor : null),
+          hash,
+        ),
         localTag: localTag,
         comments: comments,
         commentStyle: commentStyle?.ofQualified(buildStyle),
@@ -676,5 +750,9 @@ extension InjectState on TreeBuilder {
   ///
   /// This method should only be called if you are sure at least one object
   /// within the tree includes such an anchor in its properties.
-  void includeAnchors(Iterable<String> anchors) => _anchors.addAll(anchors);
+  void includeAnchors(Iterable<String> anchors) {
+    for (final anchor in anchors) {
+      _anchors[anchor] = null;
+    }
+  }
 }

--- a/packages/dump_yaml/lib/src/views/dumpable.dart
+++ b/packages/dump_yaml/lib/src/views/dumpable.dart
@@ -183,12 +183,6 @@ abstract base class ConcreteNode<To> extends DumpableView {
 
   /// Converts an object to type [To].
   ObjectFromView<To> get toFormat;
-
-  @override
-  bool operator ==(Object other) => node == other;
-
-  @override
-  int get hashCode => node.hashCode;
 }
 
 /// {@category dumpable_view}

--- a/packages/dump_yaml/lib/src/views/views.dart
+++ b/packages/dump_yaml/lib/src/views/views.dart
@@ -142,7 +142,7 @@ final class DartMap extends YamlMapping<Map<Object?, Object?>> {
 /// Helper that returns the keys of an object.
 ///
 /// {@category dump_map}
-typedef GetKeys = Iterable<Object?> Function(Object? object);
+typedef GetKeys = Set<Object?> Function(Object? object);
 
 /// Helper that reads the value of a key from a `map-like` object.
 ///
@@ -172,7 +172,7 @@ final class CustomMap extends YamlMapping<Object?> {
 
   /// Obtains the keys from a custom [node]. Duplicate keys will not have their
   /// entries visited by the `TreeBuilder`.
-  GetKeys getKeys = (o) => [o];
+  GetKeys getKeys = (o) => {o};
 
   /// Obtains the values from the [node] via its keys.
   GetValue readValue = (_, _) => null;

--- a/packages/dump_yaml/pubspec.yaml
+++ b/packages/dump_yaml/pubspec.yaml
@@ -22,6 +22,7 @@ resolution: workspace
 
 dependencies:
   collection: ^1.19.1
+  crypto: ^3.0.7
   meta: ^1.18.2
   rookie_yaml: ^0.7.0-pre.2
 

--- a/packages/dump_yaml/test/dumpable_views_test.dart
+++ b/packages/dump_yaml/test/dumpable_views_test.dart
@@ -62,7 +62,7 @@ void main() {
             {'key': 'value'},
           ])
           ..getKeys = ((obj) =>
-              (obj as Iterable).map((e) => e is MapEntry ? e.key : e))
+              (obj as Iterable).map((e) => e is MapEntry ? e.key : e).toSet())
           ..readValue = (map, current) =>
               current.index == 2 ? ((map as List)[2] as MapEntry).value : null,
       );
@@ -78,8 +78,8 @@ void main() {
 
       treeBuilder.buildFor(
         CustomMap(
-          [map, DartMap(map), list, YamlIterable(list)],
-        )..getKeys = (object) => (object as List),
+          {map, DartMap(map), list, YamlIterable(list)},
+        )..getKeys = (object) => (object as Set),
       );
 
       check(

--- a/packages/dump_yaml/test/dumpable_views_test.dart
+++ b/packages/dump_yaml/test/dumpable_views_test.dart
@@ -48,7 +48,7 @@ void main() {
       check(treeBuilder.builtNode()).isA<CollectionNode<MappingEntry>>()
         ..hasStyle(NodeStyle.block)
         ..hasTag(null)
-        ..hasAnchor(null);
+        ..hasAnchor('recursive');
     });
 
     test('Removes duplicates from a custom YamlMapping', () {

--- a/packages/dump_yaml/test/more_equality_test.dart
+++ b/packages/dump_yaml/test/more_equality_test.dart
@@ -1,0 +1,87 @@
+import 'package:checks/checks.dart';
+import 'package:dump_yaml/src/configs.dart';
+import 'package:dump_yaml/src/dumper/yaml_dumper.dart';
+import 'package:dump_yaml/src/views/dumpable.dart';
+import 'package:dump_yaml/src/views/views.dart';
+import 'package:rookie_yaml/rookie_yaml.dart';
+import 'package:test/test.dart';
+
+ScalarResolver<int> _helper(TagShorthand tag, int radix) {
+  return ScalarResolver.onMatch(
+    tag,
+    contentResolver: (i) => int.parse(i, radix: radix),
+    toYamlSafe: (i) => i.toRadixString(radix),
+  );
+}
+
+void main() {
+  // TODO: More tests
+  group('Scalars', () {
+    test('Builder weeds out duplicate entries using their generic type', () {
+      check(
+        dumpAsYaml(
+          CustomMap({
+            ScalarView(24),
+            ScalarView(24),
+            ScalarView('hello'),
+            ScalarView('hello'),
+          })..getKeys = ((object) => object as Set),
+        ),
+      ).equals('''
+24: null
+hello: null
+''');
+    });
+
+    test(
+      'Integers with the same string content but different tags are not equal',
+      () {
+        // A tag in `package:rookie_yaml` forces a scalar to be resolved
+        // differently.
+        final intString = '12345670';
+
+        final base8 = TagShorthand.primary('base8');
+        final base10 = TagShorthand.primary('base10');
+        final base16 = TagShorthand.primary('base16');
+
+        final dumped = dumpAsYaml(
+          CustomMap({
+              ScalarView(intString)..withNodeTag(base16),
+              ScalarView(intString)..withNodeTag(base10),
+              ScalarView(intString)..withNodeTag(base8),
+            })
+            ..getKeys = ((object) => object as Set)
+            ..readValue = (_, _) => '',
+          config: Config.yaml(
+            styling: TreeConfig.flow(
+              emptyAsNull: false,
+              scalarStyle: ScalarStyle.plain,
+              forceInline: true,
+            ),
+          ),
+        );
+
+        check(
+          dumped,
+        ).equals('{$base16 $intString, $base10 $intString, $base8 $intString}');
+
+        check(
+          loadObject(
+            YamlSource.simpleString(dumped),
+            triggers: CustomTriggers(
+              resolvers: [
+                _helper(base8, 8),
+                _helper(base10, 10),
+                _helper(base16, 16),
+              ],
+            ),
+          ),
+        ).isA<Map>().deepEquals({
+          int.parse(intString, radix: 16): null,
+          int.parse(intString, radix: 10): null,
+          int.parse(intString, radix: 8): null,
+        });
+      },
+    );
+  });
+}

--- a/packages/dump_yaml/test/scalar_test.dart
+++ b/packages/dump_yaml/test/scalar_test.dart
@@ -54,7 +54,7 @@ void main() {
           )
           ..dump('');
 
-        check(buffer.toString()).equals('""');
+        check(buffer.toString()).equals('');
       },
     );
 

--- a/packages/dump_yaml/test/trailing_comments_test.dart
+++ b/packages/dump_yaml/test/trailing_comments_test.dart
@@ -137,51 +137,61 @@ void main() {
   test('Dumps keys as explicit if trailing comments are present', () {
     dumper.reset(config: Config.defaults());
 
-    final map = flowNodes.fold(
-      <DumpableView, String>{},
-      (m, e) => m..[e] = 'value',
+    final orderedMap = flowNodes.fold(
+      <Map<DumpableView, String>>[],
+      (m, e) => m..add({e: 'value'}),
     );
-    dumper.dump(map);
+    dumper.dump(orderedMap);
 
     check(buffer.toString()).equals('''
-? 24 # trailing
-     # comments
-: value
-? '24' # trailing
+- ? 24 # trailing
        # comments
-: value
-? "24" # trailing
+  : value
+- ? '24' # trailing
+         # comments
+  : value
+- ? "24" # trailing
+         # comments
+  : value
+- ? [] # trailing
        # comments
-: value
-? [] # trailing
-     # comments
-: value
-? {} # trailing
-     # comments
-: value
+  : value
+- ? {} # trailing
+       # comments
+  : value
 ''');
 
     buffer.clear();
-    dumper.dump(DartMap(map)..nodeStyle = NodeStyle.flow);
+    dumper.dump(YamlIterable(orderedMap)..nodeStyle = NodeStyle.flow);
 
     check(buffer.toString()).equals('''
-{
-  ? 24 # trailing
-       # comments
-  : value,
-  ? '24' # trailing
+[
+  {
+    ? 24 # trailing
          # comments
-  : value,
-  ? "24" # trailing
+    : value
+  },
+  {
+    ? '24' # trailing
+           # comments
+    : value
+  },
+  {
+    ? "24" # trailing
+           # comments
+    : value
+  },
+  {
+    ? [] # trailing
          # comments
-  : value,
-  ? [] # trailing
-       # comments
-  : value,
-  ? {} # trailing
-       # comments
-  : value
-}''');
+    : value
+  },
+  {
+    ? {} # trailing
+         # comments
+    : value
+  }
+]''');
   });
 
   test('Ignores comments when a flow collection is inlined', () {


### PR DESCRIPTION
This PR matches `package:rookie_yaml`'s & `YAML`'s recommendation for parser implementations when handling tags. You can bind a `ScalarResolver` or `CustomResolver` to a tag in `package:rookie_yaml` whose equality implementation may change how Dart evaluates its equality to other objects.